### PR TITLE
Change String to &str

### DIFF
--- a/src/accelerators/bvh.rs
+++ b/src/accelerators/bvh.rs
@@ -174,8 +174,7 @@ impl BVHAccel {
         unwrapped.ok().unwrap()
     }
     pub fn create(prims: Vec<Arc<Primitive + Send + Sync>>, ps: &ParamSet) -> Arc<BVHAccel> {
-        let split_method_name: String =
-            ps.find_one_string(String::from("splitmethod"), String::from("sah"));
+        let split_method_name: String = ps.find_one_string("splitmethod", String::from("sah"));
         let split_method;
         if split_method_name == String::from("sah") {
             split_method = SplitMethod::SAH;
@@ -192,7 +191,7 @@ impl BVHAccel {
             );
             split_method = SplitMethod::SAH;
         }
-        let max_prims_in_node: i32 = ps.find_one_int(String::from("maxnodeprims"), 4);
+        let max_prims_in_node: i32 = ps.find_one_int("maxnodeprims", 4);
         Arc::new(BVHAccel::new(
             prims.clone(),
             max_prims_in_node as usize,

--- a/src/cameras/environment.rs
+++ b/src/cameras/environment.rs
@@ -47,14 +47,14 @@ impl EnvironmentCamera {
         film: Arc<Film>,
         medium: Option<Arc<Medium + Send + Sync>>,
     ) -> Arc<Camera + Send + Sync> {
-        let shutteropen: Float = params.find_one_float(String::from("shutteropen"), 0.0);
-        let shutterclose: Float = params.find_one_float(String::from("shutterclose"), 1.0);
+        let shutteropen: Float = params.find_one_float("shutteropen", 0.0);
+        let shutterclose: Float = params.find_one_float("shutterclose", 1.0);
         // TODO: std::swap(shutterclose, shutteropen);
         assert!(shutterclose >= shutteropen);
         // let lensradius: Float = params.find_one_float(String::from("lensradius"), 0.0);
         // let focaldistance: Float = params.find_one_float(String::from("focaldistance"), 1e30);
         let frame: Float = params.find_one_float(
-            String::from("frameaspectratio"),
+            "frameaspectratio",
             (film.full_resolution.x as Float) / (film.full_resolution.y as Float),
         );
         let mut screen: Bounds2f = Bounds2f::default();
@@ -69,7 +69,7 @@ impl EnvironmentCamera {
             screen.p_min.y = -1.0 / frame;
             screen.p_max.y = 1.0 / frame;
         }
-        let sw: Vec<Float> = params.find_float(String::from("screenwindow"));
+        let sw: Vec<Float> = params.find_float("screenwindow");
         if sw.len() > 0_usize {
             if sw.len() == 4 {
                 screen.p_min.x = sw[0];

--- a/src/cameras/orthographic.rs
+++ b/src/cameras/orthographic.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 use core::camera::{Camera, CameraSample};
 use core::film::Film;
 use core::geometry::vec3_normalize;
-use core::geometry::{
-    Bounds2f, Point2f, Point3f, Ray, RayDifferential, Vector3f,
-};
+use core::geometry::{Bounds2f, Point2f, Point3f, Ray, RayDifferential, Vector3f};
 use core::interaction::InteractionCommon;
 use core::light::VisibilityTester;
 use core::medium::Medium;
@@ -105,14 +103,14 @@ impl OrthographicCamera {
         film: Arc<Film>,
         medium: Option<Arc<Medium + Send + Sync>>,
     ) -> Arc<Camera + Send + Sync> {
-        let shutteropen: Float = params.find_one_float(String::from("shutteropen"), 0.0);
-        let shutterclose: Float = params.find_one_float(String::from("shutterclose"), 1.0);
+        let shutteropen: Float = params.find_one_float("shutteropen", 0.0);
+        let shutterclose: Float = params.find_one_float("shutterclose", 1.0);
         // TODO: std::swap(shutterclose, shutteropen);
         assert!(shutterclose >= shutteropen);
-        let lensradius: Float = params.find_one_float(String::from("lensradius"), 0.0);
-        let focaldistance: Float = params.find_one_float(String::from("focaldistance"), 1e6);
+        let lensradius: Float = params.find_one_float("lensradius", 0.0);
+        let focaldistance: Float = params.find_one_float("focaldistance", 1e6);
         let frame: Float = params.find_one_float(
-            String::from("frameaspectratio"),
+            "frameaspectratio",
             (film.full_resolution.x as Float) / (film.full_resolution.y as Float),
         );
         let mut screen: Bounds2f = Bounds2f::default();
@@ -127,7 +125,7 @@ impl OrthographicCamera {
             screen.p_min.y = -1.0 / frame;
             screen.p_max.y = 1.0 / frame;
         }
-        let sw: Vec<Float> = params.find_float(String::from("screenwindow"));
+        let sw: Vec<Float> = params.find_float("screenwindow");
         if sw.len() > 0_usize {
             if sw.len() == 4 {
                 screen.p_min.x = sw[0];
@@ -216,7 +214,9 @@ impl Camera for OrthographicCamera {
                 z: 0.0 as Float,
             };
             diff.rx_direction = vec3_normalize(&(p_focus - diff.rx_origin));
-            let p_focus: Point3f = p_camera + self.dy_camera + (Vector3f {
+            let p_focus: Point3f = p_camera
+                + self.dy_camera
+                + (Vector3f {
                     x: 0.0 as Float,
                     y: 0.0 as Float,
                     z: 1.0 as Float,

--- a/src/cameras/perspective.rs
+++ b/src/cameras/perspective.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 // pbrt
 use core::camera::{Camera, CameraSample};
 use core::film::Film;
-use core::geometry::{Bounds2f, Bounds2i, Normal3f, Point2f, Point2i, Point3f, Ray,
-                     RayDifferential, Vector3f};
 use core::geometry::{nrm_abs_dot_vec3, vec3_dot_vec3, vec3_normalize};
+use core::geometry::{
+    Bounds2f, Bounds2i, Normal3f, Point2f, Point2i, Point3f, Ray, RayDifferential, Vector3f,
+};
 use core::interaction::InteractionCommon;
 use core::light::VisibilityTester;
 use core::medium::{Medium, MediumInterface};
@@ -133,14 +134,14 @@ impl PerspectiveCamera {
         film: Arc<Film>,
         medium: Option<Arc<Medium + Send + Sync>>,
     ) -> Arc<Camera + Send + Sync> {
-        let shutteropen: Float = params.find_one_float(String::from("shutteropen"), 0.0);
-        let shutterclose: Float = params.find_one_float(String::from("shutterclose"), 1.0);
+        let shutteropen: Float = params.find_one_float("shutteropen", 0.0);
+        let shutterclose: Float = params.find_one_float("shutterclose", 1.0);
         // TODO: std::swap(shutterclose, shutteropen);
         assert!(shutterclose >= shutteropen);
-        let lensradius: Float = params.find_one_float(String::from("lensradius"), 0.0);
-        let focaldistance: Float = params.find_one_float(String::from("focaldistance"), 1e6);
+        let lensradius: Float = params.find_one_float("lensradius", 0.0);
+        let focaldistance: Float = params.find_one_float("focaldistance", 1e6);
         let frame: Float = params.find_one_float(
-            String::from("frameaspectratio"),
+            "frameaspectratio",
             (film.full_resolution.x as Float) / (film.full_resolution.y as Float),
         );
         let mut screen: Bounds2f = Bounds2f::default();
@@ -156,7 +157,7 @@ impl PerspectiveCamera {
             screen.p_max.y = 1.0 / frame;
         }
         // TODO: const Float *sw = params.FindFloat("screenwindow", &swi);
-        let fov: Float = params.find_one_float(String::from("fov"), 90.0);
+        let fov: Float = params.find_one_float("fov", 90.0);
         // let halffov: Float =
         //     params.find_one_float(String::from("halffov"), -1.0);
         // TODO: if (halffov > 0.f)

--- a/src/cameras/realistic.rs
+++ b/src/cameras/realistic.rs
@@ -73,7 +73,7 @@ impl RealisticCamera {
                 eta: lens_data[i + 2],
                 aperture_radius: diameter * 0.001 as Float / 2.0 as Float,
             });
-            println!("{:?}", element_interfaces[i/4]);
+            println!("{:?}", element_interfaces[i / 4]);
         }
         // compute lens--film distance for given focus distance
         // WORK
@@ -95,13 +95,12 @@ impl RealisticCamera {
         medium: Option<Arc<Medium + Send + Sync>>,
         search_directory: Option<&Box<PathBuf>>,
     ) -> Arc<Camera + Send + Sync> {
-        let shutteropen: Float = params.find_one_float(String::from("shutteropen"), 0.0);
-        let shutterclose: Float = params.find_one_float(String::from("shutterclose"), 1.0);
+        let shutteropen: Float = params.find_one_float("shutteropen", 0.0);
+        let shutterclose: Float = params.find_one_float("shutterclose", 1.0);
         // TODO: std::swap(shutterclose, shutteropen);
         assert!(shutterclose >= shutteropen);
         // realistic camera-specific parameters
-        let mut lens_file: String =
-            params.find_one_filename(String::from("lensfile"), String::from(""));
+        let mut lens_file: String = params.find_one_filename("lensfile", String::from(""));
         if lens_file != String::from("") {
             if let Some(ref search_directory) = search_directory {
                 let mut path_buf: PathBuf = PathBuf::from("/");
@@ -115,9 +114,9 @@ impl RealisticCamera {
         } else {
             println!("lens_file = {:?}", lens_file);
         }
-        let aperture_diameter: Float = params.find_one_float(String::from("aperturediameter"), 1.0);
-        let focus_distance: Float = params.find_one_float(String::from("focusdistance"), 10.0);
-        let simple_weighting: bool = params.find_one_bool(String::from("simpleweighting"), true);
+        let aperture_diameter: Float = params.find_one_float("aperturediameter", 1.0);
+        let focus_distance: Float = params.find_one_float("focusdistance", 10.0);
+        let simple_weighting: bool = params.find_one_bool("simpleweighting", true);
         let mut lens_data: Vec<Float> = Vec::new();
         if !read_float_file(&lens_file, &mut lens_data) {
             println!(

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -318,33 +318,33 @@ fn create_material(
         } else if api_state.graphics_state.material == String::from("matte") {
             return Some(MatteMaterial::create(&mut mp));
         } else if api_state.graphics_state.material == String::from("plastic") {
-            let kd = mp.get_spectrum_texture(String::from("Kd"), Spectrum::new(0.25 as Float));
-            let ks = mp.get_spectrum_texture(String::from("Ks"), Spectrum::new(0.25 as Float));
-            let roughness = mp.get_float_texture(String::from("roughness"), 0.1 as Float);
+            let kd = mp.get_spectrum_texture("Kd", Spectrum::new(0.25 as Float));
+            let ks = mp.get_spectrum_texture("Ks", Spectrum::new(0.25 as Float));
+            let roughness = mp.get_float_texture("roughness", 0.1 as Float);
             // TODO: std::shared_ptr<Texture<Float>> bumpMap = mp.GetFloatTextureOrNull("bumpmap");
-            let remap_roughness: bool = mp.find_bool(String::from("remaproughness"), true);
+            let remap_roughness: bool = mp.find_bool("remaproughness", true);
             let plastic = Arc::new(PlasticMaterial::new(kd, ks, roughness, remap_roughness));
             return Some(plastic);
         } else if api_state.graphics_state.material == String::from("translucent") {
             println!("TODO: CreateTranslucentMaterial");
         } else if api_state.graphics_state.material == String::from("glass") {
-            let kr = mp.get_spectrum_texture(String::from("Kr"), Spectrum::new(1.0 as Float));
-            let kt = mp.get_spectrum_texture(String::from("Kt"), Spectrum::new(1.0 as Float));
+            let kr = mp.get_spectrum_texture("Kr", Spectrum::new(1.0 as Float));
+            let kt = mp.get_spectrum_texture("Kt", Spectrum::new(1.0 as Float));
             // let some_eta = mp.get_float_texture_or_null(String::from("eta"));
             // if let Some(eta) = some_eta {
             //     println!("some eta");
             // } else {
-            let eta = mp.get_float_texture(String::from("index"), 1.5);
+            let eta = mp.get_float_texture("index", 1.5);
             // }
             // std::shared_ptr<Texture<Float>> roughu =
             //     mp.GetFloatTexture("uroughness", 0.f);
-            let roughu = mp.get_float_texture(String::from("uroughness"), 0.0 as Float);
+            let roughu = mp.get_float_texture("uroughness", 0.0 as Float);
             // std::shared_ptr<Texture<Float>> roughv =
             //     mp.GetFloatTexture("vroughness", 0.f);
-            let roughv = mp.get_float_texture(String::from("vroughness"), 0.0 as Float);
+            let roughv = mp.get_float_texture("vroughness", 0.0 as Float);
             // std::shared_ptr<Texture<Float>> bumpMap =
             //     mp.GetFloatTextureOrNull("bumpmap");
-            let remap_roughness: bool = mp.find_bool(String::from("remaproughness"), true);
+            let remap_roughness: bool = mp.find_bool("remaproughness", true);
             let glass = Arc::new(GlassMaterial {
                 kr: kr,
                 kt: kt,
@@ -355,15 +355,15 @@ fn create_material(
             });
             return Some(glass);
         } else if api_state.graphics_state.material == String::from("mirror") {
-            let kr = mp.get_spectrum_texture(String::from("Kr"), Spectrum::new(0.9 as Float));
+            let kr = mp.get_spectrum_texture("Kr", Spectrum::new(0.9 as Float));
             // TODO: std::shared_ptr<Texture<Float>> bumpMap = mp.GetFloatTextureOrNull("bumpmap");
             let mirror = Arc::new(MirrorMaterial { kr: kr });
             return Some(mirror);
         } else if api_state.graphics_state.material == String::from("hair") {
             return Some(HairMaterial::create(&mut mp));
         } else if api_state.graphics_state.material == String::from("mix") {
-            let m1: String = mp.find_string(String::from("namedmaterial1"), String::from(""));
-            let m2: String = mp.find_string(String::from("namedmaterial2"), String::from(""));
+            let m1: String = mp.find_string("namedmaterial1", String::from(""));
+            let m2: String = mp.find_string("namedmaterial2", String::from(""));
             let mat1 = match api_state.graphics_state.named_materials.get(&m1) {
                 Some(named_material) => named_material,
                 None => {
@@ -377,7 +377,7 @@ fn create_material(
                 }
             };
             let scale: Arc<Texture<Spectrum> + Send + Sync> =
-                mp.get_spectrum_texture(String::from("amount"), Spectrum::new(0.5));
+                mp.get_spectrum_texture("amount", Spectrum::new(0.5));
             if let Some(m1) = mat1 {
                 if let Some(m2) = mat2 {
                     let mix = Arc::new(MixMaterial::new(m1.clone(), m2.clone(), scale));
@@ -449,13 +449,13 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
     if api_state.param_set.name == String::from("point") {
         let i: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("I"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("I", Spectrum::new(1.0 as Float));
         let sc: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("scale"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("scale", Spectrum::new(1.0 as Float));
         let p: Point3f = api_state
             .param_set
-            .find_one_point3f(String::from("from"), Point3f::default());
+            .find_one_point3f("from", Point3f::default());
         let l2w: Transform = Transform::translate(&Vector3f {
             x: p.x,
             y: p.y,
@@ -467,19 +467,19 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
         // CreateSpotLight
         let i: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("I"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("I", Spectrum::new(1.0 as Float));
         let sc: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("scale"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("scale", Spectrum::new(1.0 as Float));
         let coneangle: Float = api_state
             .param_set
-            .find_one_float(String::from("coneangle"), 30.0 as Float);
+            .find_one_float("coneangle", 30.0 as Float);
         let conedelta: Float = api_state
             .param_set
-            .find_one_float(String::from("conedeltaangle"), 5.0 as Float);
+            .find_one_float("conedeltaangle", 5.0 as Float);
         // compute spotlight world to light transformation
         let from: Point3f = api_state.param_set.find_one_point3f(
-            String::from("from"),
+            "from",
             Point3f {
                 x: 0.0,
                 y: 0.0,
@@ -487,7 +487,7 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
             },
         );
         let to: Point3f = api_state.param_set.find_one_point3f(
-            String::from("to"),
+            "to",
             Point3f {
                 x: 0.0,
                 y: 0.0,
@@ -526,12 +526,12 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
         // CreateDistantLight
         let l: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("L"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("L", Spectrum::new(1.0 as Float));
         let sc: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("scale"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("scale", Spectrum::new(1.0 as Float));
         let from: Point3f = api_state.param_set.find_one_point3f(
-            String::from("from"),
+            "from",
             Point3f {
                 x: 0.0,
                 y: 0.0,
@@ -539,7 +539,7 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
             },
         );
         let to: Point3f = api_state.param_set.find_one_point3f(
-            String::from("to"),
+            "to",
             Point3f {
                 x: 0.0,
                 y: 0.0,
@@ -559,13 +559,13 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
     {
         let l: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("L"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("L", Spectrum::new(1.0 as Float));
         let sc: Spectrum = api_state
             .param_set
-            .find_one_spectrum(String::from("scale"), Spectrum::new(1.0 as Float));
+            .find_one_spectrum("scale", Spectrum::new(1.0 as Float));
         let mut texmap: String = api_state
             .param_set
-            .find_one_filename(String::from("mapname"), String::from(""));
+            .find_one_filename("mapname", String::from(""));
         if texmap != String::from("") {
             if let Some(ref search_directory) = api_state.search_directory {
                 // texmap = AbsolutePath(ResolveFilename(texmap));
@@ -575,9 +575,7 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
                 texmap = String::from(path_buf.to_str().unwrap());
             }
         }
-        let n_samples: i32 = api_state
-            .param_set
-            .find_one_int(String::from("nsamples"), 1 as i32);
+        let n_samples: i32 = api_state.param_set.find_one_int("nsamples", 1 as i32);
         // TODO: if (PbrtOptions.quickRender) nSamples = std::max(1, nSamples / 4);
 
         // return std::make_shared<InfiniteAreaLight>(light2world, L * sc, nSamples, texmap);
@@ -594,9 +592,7 @@ fn make_light(api_state: &mut ApiState, medium_interface: &MediumInterface) {
 }
 
 fn make_medium(api_state: &mut ApiState) {
-    let medium_type: String = api_state
-        .param_set
-        .find_one_string(String::from("type"), String::new());
+    let medium_type: String = api_state.param_set.find_one_string("type", String::new());
     if medium_type == String::from("") {
         panic!("ERROR: No parameter string \"type\" found in MakeNamedMedium");
     }
@@ -605,9 +601,7 @@ fn make_medium(api_state: &mut ApiState) {
     let sig_s_rgb: [Float; 3] = [2.55, 3.21, 3.77];
     let mut sig_a: Spectrum = Spectrum::from_rgb(&sig_a_rgb);
     let mut sig_s: Spectrum = Spectrum::from_rgb(&sig_s_rgb);
-    let preset: String = api_state
-        .param_set
-        .find_one_string(String::from("preset"), String::new());
+    let preset: String = api_state.param_set.find_one_string("preset", String::new());
     let found: bool = get_medium_scattering_properties(&preset, &mut sig_a, &mut sig_s);
     if preset != String::from("") && !found {
         println!(
@@ -615,20 +609,10 @@ fn make_medium(api_state: &mut ApiState) {
             preset
         );
     }
-    let scale: Float = api_state
-        .param_set
-        .find_one_float(String::from("scale"), 1.0 as Float);
-    let g: Float = api_state
-        .param_set
-        .find_one_float(String::from("g"), 0.0 as Float);
-    sig_a = api_state
-        .param_set
-        .find_one_spectrum(String::from("sigma_a"), sig_a)
-        * scale;
-    sig_s = api_state
-        .param_set
-        .find_one_spectrum(String::from("sigma_s"), sig_s)
-        * scale;
+    let scale: Float = api_state.param_set.find_one_float("scale", 1.0 as Float);
+    let g: Float = api_state.param_set.find_one_float("g", 0.0 as Float);
+    sig_a = api_state.param_set.find_one_spectrum("sigma_a", sig_a) * scale;
+    sig_s = api_state.param_set.find_one_spectrum("sigma_s", sig_s) * scale;
     let some_medium: Option<Arc<Medium + Sync + Send>>;
     if medium_type == String::from("homogeneous") {
         some_medium = Some(Arc::new(HomogeneousMedium::new(&sig_a, &sig_s, g)));
@@ -674,8 +658,8 @@ fn make_texture(api_state: &mut ApiState) {
             println!("TODO: CreateConstantFloatTexture");
         } else if api_state.param_set.tex_name == String::from("scale") {
             let ft = Arc::new(ScaleTexture::<Float>::new(
-                tp.get_float_texture(String::from("tex1"), 1.0 as Float),
-                tp.get_float_texture(String::from("tex2"), 1.0 as Float),
+                tp.get_float_texture("tex1", 1.0 as Float),
+                tp.get_float_texture("tex2", 1.0 as Float),
             ));
             api_state
                 .graphics_state
@@ -688,12 +672,12 @@ fn make_texture(api_state: &mut ApiState) {
         } else if api_state.param_set.tex_name == String::from("imagemap") {
             // CreateImageFloatTexture
             let mut map: Option<Box<TextureMapping2D + Send + Sync>> = None;
-            let mapping: String = tp.find_string(String::from("mapping"), String::from("uv"));
+            let mapping: String = tp.find_string("mapping", String::from("uv"));
             if mapping == String::from("uv") {
-                let su: Float = tp.find_float(String::from("uscale"), 1.0);
-                let sv: Float = tp.find_float(String::from("vscale"), 1.0);
-                let du: Float = tp.find_float(String::from("udelta"), 0.0);
-                let dv: Float = tp.find_float(String::from("vdelta"), 0.0);
+                let su: Float = tp.find_float("uscale", 1.0);
+                let sv: Float = tp.find_float("vscale", 1.0);
+                let du: Float = tp.find_float("udelta", 0.0);
+                let dv: Float = tp.find_float("vdelta", 0.0);
                 map = Some(Box::new(UVMapping2D {
                     su: su,
                     sv: sv,
@@ -707,7 +691,7 @@ fn make_texture(api_state: &mut ApiState) {
             } else if mapping == String::from("planar") {
                 map = Some(Box::new(PlanarMapping2D {
                     vs: tp.find_vector3f(
-                        String::from("v1"),
+                        "v1",
                         Vector3f {
                             x: 1.0,
                             y: 0.0,
@@ -715,31 +699,31 @@ fn make_texture(api_state: &mut ApiState) {
                         },
                     ),
                     vt: tp.find_vector3f(
-                        String::from("v2"),
+                        "v2",
                         Vector3f {
                             x: 0.0,
                             y: 1.0,
                             z: 0.0,
                         },
                     ),
-                    ds: tp.find_float(String::from("udelta"), 0.0),
-                    dt: tp.find_float(String::from("vdelta"), 0.0),
+                    ds: tp.find_float("udelta", 0.0),
+                    dt: tp.find_float("vdelta", 0.0),
                 }));
             } else {
                 panic!("2D texture mapping \"{}\" unknown", mapping);
             }
             // initialize _ImageTexture_ parameters
-            let max_aniso: Float = tp.find_float(String::from("maxanisotropy"), 8.0);
-            let do_trilinear: bool = tp.find_bool(String::from("trilinear"), false);
-            let wrap: String = tp.find_string(String::from("wrap"), String::from("repeat"));
+            let max_aniso: Float = tp.find_float("maxanisotropy", 8.0);
+            let do_trilinear: bool = tp.find_bool("trilinear", false);
+            let wrap: String = tp.find_string("wrap", String::from("repeat"));
             let mut wrap_mode: ImageWrap = ImageWrap::Repeat;
             if wrap == String::from("black") {
                 wrap_mode = ImageWrap::Black;
             } else if wrap == String::from("clamp") {
                 wrap_mode = ImageWrap::Clamp;
             }
-            let scale: Float = tp.find_float(String::from("scale"), 1.0);
-            let mut filename: String = tp.find_filename(String::from("filename"), String::new());
+            let scale: Float = tp.find_float("scale", 1.0);
+            let mut filename: String = tp.find_filename("filename", String::new());
             if let Some(ref search_directory) = api_state.search_directory {
                 // filename = AbsolutePath(ResolveFilename(filename));
                 let mut path_buf: PathBuf = PathBuf::from("/");
@@ -752,7 +736,7 @@ fn make_texture(api_state: &mut ApiState) {
             // ".tga") ||
             // HasExtension(filename,
             // ".png"));
-            let gamma: bool = tp.find_bool(String::from("gamma"), true);
+            let gamma: bool = tp.find_bool("gamma", true);
 
             if let Some(mapping) = map {
                 let ft = Arc::new(ImageTexture::new(
@@ -811,9 +795,9 @@ fn make_texture(api_state: &mut ApiState) {
             println!("TODO: CreateConstantSpectrumTexture");
         } else if api_state.param_set.tex_name == String::from("scale") {
             let tex1: Arc<Texture<Spectrum> + Send + Sync> =
-                tp.get_spectrum_texture(String::from("tex1"), Spectrum::new(1.0));
+                tp.get_spectrum_texture("tex1", Spectrum::new(1.0));
             let tex2: Arc<Texture<Spectrum> + Send + Sync> =
-                tp.get_spectrum_texture(String::from("tex2"), Spectrum::new(0.0));
+                tp.get_spectrum_texture("tex2", Spectrum::new(0.0));
             let ft = Arc::new(ScaleTexture::<Spectrum>::new(tex1, tex2));
             api_state
                 .graphics_state
@@ -826,12 +810,12 @@ fn make_texture(api_state: &mut ApiState) {
         } else if api_state.param_set.tex_name == String::from("imagemap") {
             // CreateImageSpectrumTexture
             let mut map: Option<Box<TextureMapping2D + Send + Sync>> = None;
-            let mapping: String = tp.find_string(String::from("mapping"), String::from("uv"));
+            let mapping: String = tp.find_string("mapping", String::from("uv"));
             if mapping == String::from("uv") {
-                let su: Float = tp.find_float(String::from("uscale"), 1.0);
-                let sv: Float = tp.find_float(String::from("vscale"), 1.0);
-                let du: Float = tp.find_float(String::from("udelta"), 0.0);
-                let dv: Float = tp.find_float(String::from("vdelta"), 0.0);
+                let su: Float = tp.find_float("uscale", 1.0);
+                let sv: Float = tp.find_float("vscale", 1.0);
+                let du: Float = tp.find_float("udelta", 0.0);
+                let dv: Float = tp.find_float("vdelta", 0.0);
                 map = Some(Box::new(UVMapping2D {
                     su: su,
                     sv: sv,
@@ -845,7 +829,7 @@ fn make_texture(api_state: &mut ApiState) {
             } else if mapping == String::from("planar") {
                 map = Some(Box::new(PlanarMapping2D {
                     vs: tp.find_vector3f(
-                        String::from("v1"),
+                        "v1",
                         Vector3f {
                             x: 1.0,
                             y: 0.0,
@@ -853,31 +837,31 @@ fn make_texture(api_state: &mut ApiState) {
                         },
                     ),
                     vt: tp.find_vector3f(
-                        String::from("v2"),
+                        "v2",
                         Vector3f {
                             x: 0.0,
                             y: 1.0,
                             z: 0.0,
                         },
                     ),
-                    ds: tp.find_float(String::from("udelta"), 0.0),
-                    dt: tp.find_float(String::from("vdelta"), 0.0),
+                    ds: tp.find_float("udelta", 0.0),
+                    dt: tp.find_float("vdelta", 0.0),
                 }));
             } else {
                 panic!("2D texture mapping \"{}\" unknown", mapping);
             }
             // initialize _ImageTexture_ parameters
-            let max_aniso: Float = tp.find_float(String::from("maxanisotropy"), 8.0);
-            let do_trilinear: bool = tp.find_bool(String::from("trilinear"), false);
-            let wrap: String = tp.find_string(String::from("wrap"), String::from("repeat"));
+            let max_aniso: Float = tp.find_float("maxanisotropy", 8.0);
+            let do_trilinear: bool = tp.find_bool("trilinear", false);
+            let wrap: String = tp.find_string("wrap", String::from("repeat"));
             let mut wrap_mode: ImageWrap = ImageWrap::Repeat;
             if wrap == String::from("black") {
                 wrap_mode = ImageWrap::Black;
             } else if wrap == String::from("clamp") {
                 wrap_mode = ImageWrap::Clamp;
             }
-            let scale: Float = tp.find_float(String::from("scale"), 1.0);
-            let mut filename: String = tp.find_filename(String::from("filename"), String::new());
+            let scale: Float = tp.find_float("scale", 1.0);
+            let mut filename: String = tp.find_filename("filename", String::new());
             if let Some(ref search_directory) = api_state.search_directory {
                 // filename = AbsolutePath(ResolveFilename(filename));
                 let mut path_buf: PathBuf = PathBuf::from("/");
@@ -890,7 +874,7 @@ fn make_texture(api_state: &mut ApiState) {
             // ".tga") ||
             // HasExtension(filename,
             // ".png"));
-            let gamma: bool = tp.find_bool(String::from("gamma"), true);
+            let gamma: bool = tp.find_bool("gamma", true);
 
             if let Some(mapping) = map {
                 let st = Arc::new(ImageTexture::new(
@@ -912,22 +896,22 @@ fn make_texture(api_state: &mut ApiState) {
             println!("TODO: CreateUVSpectrumTexture");
         } else if api_state.param_set.tex_name == String::from("checkerboard") {
             // CreateCheckerboardSpectrumTexture
-            let dim: i32 = tp.find_int(String::from("dimension"), 2);
+            let dim: i32 = tp.find_int("dimension", 2);
             if dim != 2 && dim != 3 {
                 panic!("{} dimensional checkerboard texture not supported", dim);
             }
             let tex1: Arc<Texture<Spectrum> + Send + Sync> =
-                tp.get_spectrum_texture(String::from("tex1"), Spectrum::new(1.0));
+                tp.get_spectrum_texture("tex1", Spectrum::new(1.0));
             let tex2: Arc<Texture<Spectrum> + Send + Sync> =
-                tp.get_spectrum_texture(String::from("tex2"), Spectrum::new(0.0));
+                tp.get_spectrum_texture("tex2", Spectrum::new(0.0));
             if dim == 2 {
                 let mut map: Option<Box<TextureMapping2D + Send + Sync>> = None;
-                let mapping: String = tp.find_string(String::from("mapping"), String::from("uv"));
+                let mapping: String = tp.find_string("mapping", String::from("uv"));
                 if mapping == String::from("uv") {
-                    let su: Float = tp.find_float(String::from("uscale"), 1.0);
-                    let sv: Float = tp.find_float(String::from("vscale"), 1.0);
-                    let du: Float = tp.find_float(String::from("udelta"), 0.0);
-                    let dv: Float = tp.find_float(String::from("vdelta"), 0.0);
+                    let su: Float = tp.find_float("uscale", 1.0);
+                    let sv: Float = tp.find_float("vscale", 1.0);
+                    let du: Float = tp.find_float("udelta", 0.0);
+                    let dv: Float = tp.find_float("vdelta", 0.0);
                     map = Some(Box::new(UVMapping2D {
                         su: su,
                         sv: sv,
@@ -941,7 +925,7 @@ fn make_texture(api_state: &mut ApiState) {
                 } else if mapping == String::from("planar") {
                     map = Some(Box::new(PlanarMapping2D {
                         vs: tp.find_vector3f(
-                            String::from("v1"),
+                            "v1",
                             Vector3f {
                                 x: 1.0,
                                 y: 0.0,
@@ -949,15 +933,15 @@ fn make_texture(api_state: &mut ApiState) {
                             },
                         ),
                         vt: tp.find_vector3f(
-                            String::from("v2"),
+                            "v2",
                             Vector3f {
                                 x: 0.0,
                                 y: 1.0,
                                 z: 0.0,
                             },
                         ),
-                        ds: tp.find_float(String::from("udelta"), 0.0),
-                        dt: tp.find_float(String::from("vdelta"), 0.0),
+                        ds: tp.find_float("udelta", 0.0),
+                        dt: tp.find_float("vdelta", 0.0),
                     }));
                 } else {
                     panic!("2D texture mapping \"{}\" unknown", mapping);
@@ -1030,18 +1014,10 @@ fn get_shapes_and_materials(
     // MakeShapes (api.cpp:296)
     if api_state.param_set.name == String::from("sphere") {
         // CreateSphereShape
-        let radius: Float = api_state
-            .param_set
-            .find_one_float(String::from("radius"), 1.0 as Float);
-        let z_min: Float = api_state
-            .param_set
-            .find_one_float(String::from("zmin"), -radius);
-        let z_max: Float = api_state
-            .param_set
-            .find_one_float(String::from("zmax"), radius);
-        let phi_max: Float = api_state
-            .param_set
-            .find_one_float(String::from("phimax"), 360.0 as Float);
+        let radius: Float = api_state.param_set.find_one_float("radius", 1.0 as Float);
+        let z_min: Float = api_state.param_set.find_one_float("zmin", -radius);
+        let z_max: Float = api_state.param_set.find_one_float("zmax", radius);
+        let phi_max: Float = api_state.param_set.find_one_float("phimax", 360.0 as Float);
         let sphere = Arc::new(Sphere::new(
             obj_to_world,
             world_to_obj,
@@ -1056,18 +1032,10 @@ fn get_shapes_and_materials(
         shapes.push(sphere.clone());
         materials.push(mtl);
     } else if api_state.param_set.name == String::from("cylinder") {
-        let radius: Float = api_state
-            .param_set
-            .find_one_float(String::from("radius"), 1.0);
-        let z_min: Float = api_state
-            .param_set
-            .find_one_float(String::from("zmin"), -radius);
-        let z_max: Float = api_state
-            .param_set
-            .find_one_float(String::from("zmax"), radius);
-        let phi_max: Float = api_state
-            .param_set
-            .find_one_float(String::from("phimax"), 360.0 as Float);
+        let radius: Float = api_state.param_set.find_one_float("radius", 1.0);
+        let z_min: Float = api_state.param_set.find_one_float("zmin", -radius);
+        let z_max: Float = api_state.param_set.find_one_float("zmax", radius);
+        let phi_max: Float = api_state.param_set.find_one_float("phimax", 360.0 as Float);
         let cylinder = Arc::new(Cylinder::new(
             obj_to_world,
             world_to_obj,
@@ -1081,18 +1049,10 @@ fn get_shapes_and_materials(
         shapes.push(cylinder.clone());
         materials.push(mtl.clone());
     } else if api_state.param_set.name == String::from("disk") {
-        let height: Float = api_state
-            .param_set
-            .find_one_float(String::from("height"), 0.0);
-        let radius: Float = api_state
-            .param_set
-            .find_one_float(String::from("radius"), 1.0);
-        let inner_radius: Float = api_state
-            .param_set
-            .find_one_float(String::from("innerradius"), 0.0);
-        let phi_max: Float = api_state
-            .param_set
-            .find_one_float(String::from("phimax"), 360.0);
+        let height: Float = api_state.param_set.find_one_float("height", 0.0);
+        let radius: Float = api_state.param_set.find_one_float("radius", 1.0);
+        let inner_radius: Float = api_state.param_set.find_one_float("innerradius", 0.0);
+        let phi_max: Float = api_state.param_set.find_one_float("phimax", 360.0);
         let disk = Arc::new(Disk::new(
             obj_to_world,
             world_to_obj,
@@ -1124,21 +1084,21 @@ fn get_shapes_and_materials(
             shapes.push(shape.clone());
             materials.push(mtl.clone());
         }
-    } else if api_state.param_set.name == String::from("trianglemesh") {
-        let vi = api_state.param_set.find_int(String::from("indices"));
-        let p = api_state.param_set.find_point3f(String::from("P"));
+    } else if api_state.param_set.name == "trianglemesh" {
+        let vi = api_state.param_set.find_int("indices");
+        let p = api_state.param_set.find_point3f("P");
         // try "uv" with Point2f
-        let mut uvs = api_state.param_set.find_point2f(String::from("uv"));
+        let mut uvs = api_state.param_set.find_point2f("uv");
         if uvs.is_empty() {
             // try "st" with Point2f
-            uvs = api_state.param_set.find_point2f(String::from("st"));
+            uvs = api_state.param_set.find_point2f("st");
         }
         if uvs.is_empty() {
             // try "uv" with float
-            let mut fuv = api_state.param_set.find_float(String::from("uv"));
+            let mut fuv = api_state.param_set.find_float("uv");
             if fuv.is_empty() {
                 // try "st" with float
-                fuv = api_state.param_set.find_float(String::from("st"));
+                fuv = api_state.param_set.find_float("st");
             }
             if !fuv.is_empty() {
                 // found some float UVs
@@ -1156,7 +1116,7 @@ fn get_shapes_and_materials(
         }
         assert!(vi.len() > 0_usize);
         assert!(p.len() > 0_usize);
-        let s = api_state.param_set.find_vector3f(String::from("S"));
+        let s = api_state.param_set.find_vector3f("S");
         let mut s_ws: Vec<Vector3f> = Vec::new();
         if !s.is_empty() {
             assert!(s.len() == p.len());
@@ -1166,7 +1126,7 @@ fn get_shapes_and_materials(
                 s_ws.push(obj_to_world.transform_vector(&s[i]));
             }
         }
-        let n = api_state.param_set.find_normal3f(String::from("N"));
+        let n = api_state.param_set.find_normal3f("N");
         let mut n_ws: Vec<Normal3f> = Vec::new();
         if !n.is_empty() {
             assert!(n.len() == p.len());
@@ -1246,13 +1206,12 @@ fn get_shapes_and_materials(
         println!("TODO: CreateHeightfield");
     } else if api_state.param_set.name == String::from("loopsubdiv") {
         // CreateLoopSubdiv
-        let n_levels: i32 = api_state.param_set.find_one_int(
-            String::from("levels"),
-            api_state.param_set.find_one_int(String::from("nlevels"), 3),
-        );
+        let n_levels: i32 = api_state
+            .param_set
+            .find_one_int("levels", api_state.param_set.find_one_int("nlevels", 3));
         // int nps, nIndices;
-        let vertex_indices: Vec<i32> = api_state.param_set.find_int(String::from("indices"));
-        let p = api_state.param_set.find_point3f(String::from("P"));
+        let vertex_indices: Vec<i32> = api_state.param_set.find_int("indices");
+        let p = api_state.param_set.find_point3f("P");
         if vertex_indices.is_empty() {
             panic!("Vertex indices \"indices\" not provided for LoopSubdiv shape.");
         }
@@ -1262,7 +1221,7 @@ fn get_shapes_and_materials(
         // don't actually use this for now...
         let _scheme: String = api_state
             .param_set
-            .find_one_string(String::from("scheme"), String::from("loop"));
+            .find_one_string("scheme", String::from("loop"));
         let mesh = loop_subdivide(
             &obj_to_world,
             &world_to_obj,
@@ -1285,15 +1244,15 @@ fn get_shapes_and_materials(
         }
     } else if api_state.param_set.name == String::from("nurbs") {
         // CreateNURBS
-        let nu: i32 = api_state.param_set.find_one_int(String::from("nu"), -1);
+        let nu: i32 = api_state.param_set.find_one_int("nu", -1);
         if nu == -1_i32 {
             panic!("Must provide number of control points \"nu\" with NURBS shape.");
         }
-        let uorder: i32 = api_state.param_set.find_one_int(String::from("uorder"), -1);
+        let uorder: i32 = api_state.param_set.find_one_int("uorder", -1);
         if uorder == -1_i32 {
             panic!("Must provide u order \"uorder\" with NURBS shape.");
         }
-        let uknots: Vec<Float> = api_state.param_set.find_float(String::from("uknots"));
+        let uknots: Vec<Float> = api_state.param_set.find_float("uknots");
         if uknots.is_empty() {
             panic!("Must provide u knot vector \"uknots\" with NURBS shape.");
         }
@@ -1303,19 +1262,19 @@ fn get_shapes_and_materials(
         }
         let u0: Float = api_state
             .param_set
-            .find_one_float(String::from("u0"), uknots[(uorder - 1) as usize]);
+            .find_one_float("u0", uknots[(uorder - 1) as usize]);
         let u1: Float = api_state
             .param_set
-            .find_one_float(String::from("u1"), uknots[nu as usize]);
-        let nv: i32 = api_state.param_set.find_one_int(String::from("nv"), -1);
+            .find_one_float("u1", uknots[nu as usize]);
+        let nv: i32 = api_state.param_set.find_one_int("nv", -1);
         if nv == -1_i32 {
             panic!("Must provide number of control points \"nv\" with NURBS shape.");
         }
-        let vorder: i32 = api_state.param_set.find_one_int(String::from("vorder"), -1);
+        let vorder: i32 = api_state.param_set.find_one_int("vorder", -1);
         if vorder == -1_i32 {
             panic!("Must provide u order \"vorder\" with NURBS shape.");
         }
-        let vknots: Vec<Float> = api_state.param_set.find_float(String::from("vknots"));
+        let vknots: Vec<Float> = api_state.param_set.find_float("vknots");
         if vknots.is_empty() {
             panic!("Must provide u knot vector \"vknots\" with NURBS shape.");
         }
@@ -1325,16 +1284,16 @@ fn get_shapes_and_materials(
         }
         let v0: Float = api_state
             .param_set
-            .find_one_float(String::from("v0"), vknots[(vorder - 1) as usize]);
+            .find_one_float("v0", vknots[(vorder - 1) as usize]);
         let v1: Float = api_state
             .param_set
-            .find_one_float(String::from("v1"), vknots[nv as usize]);
+            .find_one_float("v1", vknots[nv as usize]);
         let mut is_homogeneous: bool = false;
-        let p: Vec<Point3f> = api_state.param_set.find_point3f(String::from("P"));
+        let p: Vec<Point3f> = api_state.param_set.find_point3f("P");
         let mut pw: Vec<Float> = Vec::new();
         let mut npts: usize = p.len();
         if p.is_empty() {
-            pw = api_state.param_set.find_float(String::from("Pw"));
+            pw = api_state.param_set.find_float("Pw");
             if pw.is_empty() {
                 panic!("Must provide control points via \"P\" or \"Pw\" parameter to NURBS shape.");
             }
@@ -1613,15 +1572,15 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
         let filename: String = api_state
             .render_options
             .film_params
-            .find_one_string(String::from("filename"), String::new());
+            .find_one_string("filename", String::new());
         let xres: i32 = api_state
             .render_options
             .film_params
-            .find_one_int(String::from("xresolution"), 1280);
+            .find_one_int("xresolution", 1280);
         let yres: i32 = api_state
             .render_options
             .film_params
-            .find_one_int(String::from("yresolution"), 720);
+            .find_one_int("yresolution", 720);
         // TODO: if (PbrtOptions.quickRender) xres = std::max(1, xres / 4);
         // TODO: if (PbrtOptions.quickRender) yres = std::max(1, yres / 4);
         let mut crop: Bounds2f = Bounds2f {
@@ -1632,7 +1591,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
         let cr: Vec<Float> = api_state
             .render_options
             .film_params
-            .find_float(String::from("cropwindow"));
+            .find_float("cropwindow");
         if cr.len() == 4 {
             crop.p_min.x = clamp_t(cr[0].min(cr[1]), 0.0, 1.0);
             crop.p_max.x = clamp_t(cr[0].max(cr[1]), 0.0, 1.0);
@@ -1647,15 +1606,15 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
         let scale: Float = api_state
             .render_options
             .film_params
-            .find_one_float(String::from("scale"), 1.0);
+            .find_one_float("scale", 1.0);
         let diagonal: Float = api_state
             .render_options
             .film_params
-            .find_one_float(String::from("diagonal"), 35.0);
+            .find_one_float("diagonal", 35.0);
         let max_sample_luminance: Float = api_state
             .render_options
             .film_params
-            .find_one_float(String::from("maxsampleluminance"), std::f32::INFINITY);
+            .find_one_float("maxsampleluminance", std::f32::INFINITY);
         if let Some(filter) = some_filter {
             let film: Arc<Film> = Arc::new(Film::new(
                 Point2i { x: xres, y: yres },
@@ -1738,11 +1697,11 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                     let nsamp: i32 = api_state
                         .render_options
                         .sampler_params
-                        .find_one_int(String::from("pixelsamples"), 16);
+                        .find_one_int("pixelsamples", 16);
                     let sd: i32 = api_state
                         .render_options
                         .sampler_params
-                        .find_one_int(String::from("dimensions"), 4);
+                        .find_one_int("dimensions", 4);
                     // TODO: if (PbrtOptions.quickRender) nsamp = 1;
                     let sampler = Box::new(ZeroTwoSequenceSampler::new(nsamp as i64, sd as i64));
                     some_sampler = Some(sampler);
@@ -1752,12 +1711,12 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                     let nsamp: i32 = api_state
                         .render_options
                         .sampler_params
-                        .find_one_int(String::from("pixelsamples"), 16);
+                        .find_one_int("pixelsamples", 16);
                     // TODO: if (PbrtOptions.quickRender) nsamp = 1;
                     let sample_at_center: bool = api_state
                         .render_options
                         .integrator_params
-                        .find_one_bool(String::from("samplepixelcenter"), false);
+                        .find_one_bool("samplepixelcenter", false);
                     let sample_bounds: Bounds2i = camera.get_film().get_sample_bounds();
                     let sampler = Box::new(HaltonSampler::new(
                         nsamp as i64,
@@ -1769,7 +1728,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                     let nsamp: i32 = api_state
                         .render_options
                         .sampler_params
-                        .find_one_int(String::from("pixelsamples"), 16);
+                        .find_one_int("pixelsamples", 16);
                     let sample_bounds: Bounds2i = camera.get_film().get_sample_bounds();
                     let sampler = Box::new(SobolSampler::new(nsamp as i64, sample_bounds));
                     some_sampler = Some(sampler);
@@ -1777,7 +1736,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                     let nsamp: i32 = api_state
                         .render_options
                         .sampler_params
-                        .find_one_int(String::from("pixelsamples"), 4);
+                        .find_one_int("pixelsamples", 4);
                     let sampler = Box::new(RandomSampler::new(nsamp as i64));
                     some_sampler = Some(sampler);
                 } else if api_state.render_options.sampler_name == String::from("stratified") {
@@ -1805,11 +1764,11 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                         let max_depth: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("maxdepth"), 5);
+                            .find_one_int("maxdepth", 5);
                         let st: String = api_state
                             .render_options
                             .integrator_params
-                            .find_one_string(String::from("strategy"), String::from("all"));
+                            .find_one_string("strategy", String::from("all"));
                         let strategy: LightStrategy;
                         if st == String::from("one") {
                             strategy = LightStrategy::UniformSampleOne;
@@ -1834,11 +1793,11 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                         let max_depth: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("maxdepth"), 5);
+                            .find_one_int("maxdepth", 5);
                         let pb: Vec<i32> = api_state
                             .render_options
                             .integrator_params
-                            .find_int(String::from("pixelbounds"));
+                            .find_int("pixelbounds");
                         let np: usize = pb.len();
                         let pixel_bounds: Bounds2i = camera.get_film().get_sample_bounds();
                         if np > 0 as usize {
@@ -1858,14 +1817,13 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                         let rr_threshold: Float = api_state
                             .render_options
                             .integrator_params
-                            .find_one_float(String::from("rrthreshold"), 1.0 as Float);
+                            .find_one_float("rrthreshold", 1.0 as Float);
                         // std::string lightStrategy =
                         //     params.FindOneString("lightsamplestrategy", "spatial");
-                        let light_strategy: String =
-                            api_state.render_options.integrator_params.find_one_string(
-                                String::from("lightsamplestrategy"),
-                                String::from("spatial"),
-                            );
+                        let light_strategy: String = api_state
+                            .render_options
+                            .integrator_params
+                            .find_one_string("lightsamplestrategy", String::from("spatial"));
                         let integrator = Box::new(PathIntegrator::new(
                             max_depth as u32,
                             pixel_bounds,
@@ -1880,25 +1838,24 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                         let mut max_depth: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("maxdepth"), 5);
+                            .find_one_int("maxdepth", 5);
                         let visualize_strategies: bool = api_state
                             .render_options
                             .integrator_params
-                            .find_one_bool(String::from("visualizestrategies"), false);
+                            .find_one_bool("visualizestrategies", false);
                         let visualize_weights: bool = api_state
                             .render_options
                             .integrator_params
-                            .find_one_bool(String::from("visualizeweights"), false);
+                            .find_one_bool("visualizeweights", false);
                         if (visualize_strategies || visualize_weights) && max_depth > 5_i32 {
                             println!("WARNING: visualizestrategies/visualizeweights was enabled, limiting maxdepth to 5");
                             max_depth = 5;
                         }
                         let pixel_bounds: Bounds2i = camera.get_film().get_sample_bounds();
-                        let light_strategy: String =
-                            api_state.render_options.integrator_params.find_one_string(
-                                String::from("lightsamplestrategy"),
-                                String::from("power"),
-                            );
+                        let light_strategy: String = api_state
+                            .render_options
+                            .integrator_params
+                            .find_one_string("lightsamplestrategy", String::from("power"));
                         let mut integrator = Box::new(BDPTIntegrator::new(
                             max_depth as u32,
                             // visualize_strategies,
@@ -1912,27 +1869,27 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                         let mut max_depth: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("maxdepth"), 5);
+                            .find_one_int("maxdepth", 5);
                         let mut n_bootstrap: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("bootstrapsamples"), 100000);
+                            .find_one_int("bootstrapsamples", 100000);
                         let mut n_chains: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("chains"), 1000);
+                            .find_one_int("chains", 1000);
                         let mut mutations_per_pixel: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("mutationsperpixel"), 100);
+                            .find_one_int("mutationsperpixel", 100);
                         let large_step_probability: Float = api_state
                             .render_options
                             .integrator_params
-                            .find_one_float(String::from("largestepprobability"), 0.3 as Float);
+                            .find_one_float("largestepprobability", 0.3 as Float);
                         let sigma: Float = api_state
                             .render_options
                             .integrator_params
-                            .find_one_float(String::from("sigma"), 0.01 as Float);
+                            .find_one_float("sigma", 0.01 as Float);
                         let mut integrator = Box::new(MLTIntegrator::new(
                             camera.clone(),
                             max_depth as u32,
@@ -1950,7 +1907,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                         let pb: Vec<i32> = api_state
                             .render_options
                             .integrator_params
-                            .find_int(String::from("pixelbounds"));
+                            .find_int("pixelbounds");
                         let np: usize = pb.len();
                         let pixel_bounds: Bounds2i = camera.get_film().get_sample_bounds();
                         if np > 0 as usize {
@@ -1970,12 +1927,12 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                         let cos_sample: bool = api_state
                             .render_options
                             .integrator_params
-                            .find_one_bool(String::from("cossample"), true);
+                            .find_one_bool("cossample", true);
                         // int nSamples = params.Find_One_Int("nsamples", 64);
                         let n_samples: i32 = api_state
                             .render_options
                             .integrator_params
-                            .find_one_int(String::from("nsamples"), 64 as i32);
+                            .find_one_int("nsamples", 64 as i32);
                         // return new AOIntegrator(cosSample, nSamples, camera, sampler, pixelBounds);
 
                         let integrator =
@@ -2012,7 +1969,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                             let split_method_name: String = api_state
                                 .render_options
                                 .accelerator_params
-                                .find_one_string(String::from("splitmethod"), String::from("sah"));
+                                .find_one_string("splitmethod", String::from("sah"));
                             let split_method;
                             if split_method_name == String::from("sah") {
                                 split_method = SplitMethod::SAH;
@@ -2032,7 +1989,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                             let max_prims_in_node: i32 = api_state
                                 .render_options
                                 .accelerator_params
-                                .find_one_int(String::from("maxnodeprims"), 4);
+                                .find_one_int("maxnodeprims", 4);
                             let accelerator = Arc::new(BVHAccel::new(
                                 api_state.render_options.primitives.clone(),
                                 max_prims_in_node as usize,
@@ -2097,7 +2054,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                             let split_method_name: String = api_state
                                 .render_options
                                 .accelerator_params
-                                .find_one_string(String::from("splitmethod"), String::from("sah"));
+                                .find_one_string("splitmethod", String::from("sah"));
                             let split_method;
                             if split_method_name == String::from("sah") {
                                 split_method = SplitMethod::SAH;
@@ -2117,7 +2074,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                             let max_prims_in_node: i32 = api_state
                                 .render_options
                                 .accelerator_params
-                                .find_one_int(String::from("maxnodeprims"), 4);
+                                .find_one_int("maxnodeprims", 4);
                             let accelerator = Arc::new(BVHAccel::new(
                                 api_state.render_options.primitives.clone(),
                                 max_prims_in_node as usize,
@@ -2188,7 +2145,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                             let split_method_name: String = api_state
                                 .render_options
                                 .accelerator_params
-                                .find_one_string(String::from("splitmethod"), String::from("sah"));
+                                .find_one_string("splitmethod", String::from("sah"));
                             let split_method;
                             if split_method_name == String::from("sah") {
                                 split_method = SplitMethod::SAH;
@@ -2208,7 +2165,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
                             let max_prims_in_node: i32 = api_state
                                 .render_options
                                 .accelerator_params
-                                .find_one_int(String::from("maxnodeprims"), 4);
+                                .find_one_int("maxnodeprims", 4);
                             let accelerator = Arc::new(BVHAccel::new(
                                 api_state.render_options.primitives.clone(),
                                 max_prims_in_node as usize,
@@ -2662,9 +2619,7 @@ pub fn pbrt_make_named_material(
     // println!("MakeNamedMaterial \"{}\"", params.name);
     // print_params(&params);
     api_state.param_set = params;
-    let mat_type: String = api_state
-        .param_set
-        .find_one_string(String::from("type"), String::new());
+    let mat_type: String = api_state.param_set.find_one_string("type", String::new());
     if mat_type == String::new() {
         panic!("No parameter string \"type\" found in MakeNamedMaterial");
     }
@@ -2742,21 +2697,21 @@ pub fn pbrt_shape(api_state: &mut ApiState, bsdf_state: &mut BsdfState, params: 
                 let l: Spectrum = api_state
                     .graphics_state
                     .area_light_params
-                    .find_one_spectrum(String::from("L"), Spectrum::new(1.0));
+                    .find_one_spectrum("L", Spectrum::new(1.0));
                 let sc: Spectrum = api_state
                     .graphics_state
                     .area_light_params
-                    .find_one_spectrum(String::from("scale"), Spectrum::new(1.0));
+                    .find_one_spectrum("scale", Spectrum::new(1.0));
                 let n_samples: i32 = // try "nsamples" first
-                    api_state.graphics_state.area_light_params.find_one_int(String::from("nsamples"),
+                    api_state.graphics_state.area_light_params.find_one_int("nsamples",
                                                                   1);
                 let n_samples: i32 = // try "samples"next
-                    api_state.graphics_state.area_light_params.find_one_int(String::from("samples"),
+                    api_state.graphics_state.area_light_params.find_one_int("samples",
                                                                   n_samples);
                 let two_sided: bool = api_state
                     .graphics_state
                     .area_light_params
-                    .find_one_bool(String::from("twosided"), false);
+                    .find_one_bool("twosided", false);
                 // TODO: if (PbrtOptions.quickRender) nSamples = std::max(1, nSamples / 4);
                 let l_emit: Spectrum = l * sc;
                 let area_light: Arc<DiffuseAreaLight> = Arc::new(DiffuseAreaLight::new(
@@ -2895,7 +2850,7 @@ pub fn pbrt_object_instance(api_state: &mut ApiState, params: ParamSet) {
                 let split_method_name: String = api_state
                     .render_options
                     .accelerator_params
-                    .find_one_string(String::from("splitmethod"), String::from("sah"));
+                    .find_one_string("splitmethod", String::from("sah"));
                 let split_method;
                 if split_method_name == String::from("sah") {
                     split_method = SplitMethod::SAH;
@@ -2915,7 +2870,7 @@ pub fn pbrt_object_instance(api_state: &mut ApiState, params: ParamSet) {
                 let max_prims_in_node: i32 = api_state
                     .render_options
                     .accelerator_params
-                    .find_one_int(String::from("maxnodeprims"), 4);
+                    .find_one_int("maxnodeprims", 4);
                 let accelerator: Arc<Primitive + Sync + Send> = Arc::new(BVHAccel::new(
                     instance_vec.clone(),
                     max_prims_in_node as usize,

--- a/src/core/paramset.rs
+++ b/src/core/paramset.rs
@@ -414,7 +414,7 @@ impl ParamSet {
         }
         false
     }
-    pub fn find_one_float(&self, name: String, d: Float) -> Float {
+    pub fn find_one_float(&self, name: &str, d: Float) -> Float {
         for v in &self.floats {
             if v.name == name && v.n_values == 1 {
                 // v.looked_up = true;
@@ -423,7 +423,7 @@ impl ParamSet {
         }
         d
     }
-    pub fn find_one_int(&self, name: String, d: i32) -> i32 {
+    pub fn find_one_int(&self, name: &str, d: i32) -> i32 {
         for v in &self.ints {
             if v.name == name && v.n_values == 1 {
                 // v.looked_up = true;
@@ -432,7 +432,7 @@ impl ParamSet {
         }
         d
     }
-    pub fn find_one_bool(&self, name: String, d: bool) -> bool {
+    pub fn find_one_bool(&self, name: &str, d: bool) -> bool {
         for v in &self.bools {
             if v.name == name && v.n_values == 1 {
                 // v.looked_up = true;
@@ -441,7 +441,7 @@ impl ParamSet {
         }
         d
     }
-    pub fn find_one_point3f(&self, name: String, d: Point3f) -> Point3f {
+    pub fn find_one_point3f(&self, name: &str, d: Point3f) -> Point3f {
         for v in &self.point3fs {
             if v.name == name && v.n_values == 1 {
                 // v.looked_up = true;
@@ -450,7 +450,7 @@ impl ParamSet {
         }
         d
     }
-    pub fn find_one_vector3f(&self, name: String, d: Vector3f) -> Vector3f {
+    pub fn find_one_vector3f(&self, name: &str, d: Vector3f) -> Vector3f {
         for v in &self.vector3fs {
             if v.name == name && v.n_values == 1 {
                 // v.looked_up = true;
@@ -459,7 +459,7 @@ impl ParamSet {
         }
         d
     }
-    pub fn find_one_spectrum(&self, name: String, d: Spectrum) -> Spectrum {
+    pub fn find_one_spectrum(&self, name: &str, d: Spectrum) -> Spectrum {
         for v in &self.spectra {
             if v.name == name && v.n_values == 1 {
                 // v.looked_up = true;
@@ -468,7 +468,7 @@ impl ParamSet {
         }
         d
     }
-    pub fn find_one_string(&self, name: String, d: String) -> String {
+    pub fn find_one_string(&self, name: &str, d: String) -> String {
         for v in &self.strings {
             if v.name == name && v.n_values == 1 {
                 // v.looked_up = true;
@@ -477,7 +477,7 @@ impl ParamSet {
         }
         d
     }
-    pub fn find_one_filename(&self, name: String, d: String) -> String {
+    pub fn find_one_filename(&self, name: &str, d: String) -> String {
         let filename: String = self.find_one_string(name, String::new());
         if filename == String::new() {
             return d;
@@ -485,11 +485,11 @@ impl ParamSet {
         // TODO: filename = AbsolutePath(ResolveFilename(filename));
         filename
     }
-    pub fn find_texture(&self, name: String) -> String {
+    pub fn find_texture(&self, name: &str) -> String {
         let d: String = String::new();
         lookup_one(&self.textures, name, d)
     }
-    pub fn find_int(&self, name: String) -> Vec<i32> {
+    pub fn find_int(&self, name: &str) -> Vec<i32> {
         let mut values: Vec<i32> = Vec::new();
         for v in &self.ints {
             if v.name == name {
@@ -502,7 +502,7 @@ impl ParamSet {
         }
         values
     }
-    pub fn find_float(&self, name: String) -> Vec<Float> {
+    pub fn find_float(&self, name: &str) -> Vec<Float> {
         let mut values: Vec<Float> = Vec::new();
         for v in &self.floats {
             if v.name == name {
@@ -515,7 +515,7 @@ impl ParamSet {
         }
         values
     }
-    pub fn find_point2f(&self, name: String) -> Vec<Point2f> {
+    pub fn find_point2f(&self, name: &str) -> Vec<Point2f> {
         let mut values: Vec<Point2f> = Vec::new();
         for v in &self.point2fs {
             if v.name == name {
@@ -528,7 +528,7 @@ impl ParamSet {
         }
         values
     }
-    pub fn find_vector2f(&self, name: String) -> Vec<Vector2f> {
+    pub fn find_vector2f(&self, name: &str) -> Vec<Vector2f> {
         let mut values: Vec<Vector2f> = Vec::new();
         for v in &self.vector2fs {
             if v.name == name {
@@ -541,7 +541,7 @@ impl ParamSet {
         }
         values
     }
-    pub fn find_point3f(&self, name: String) -> Vec<Point3f> {
+    pub fn find_point3f(&self, name: &str) -> Vec<Point3f> {
         let mut values: Vec<Point3f> = Vec::new();
         for v in &self.point3fs {
             if v.name == name {
@@ -554,7 +554,7 @@ impl ParamSet {
         }
         values
     }
-    pub fn find_vector3f(&self, name: String) -> Vec<Vector3f> {
+    pub fn find_vector3f(&self, name: &str) -> Vec<Vector3f> {
         let mut values: Vec<Vector3f> = Vec::new();
         for v in &self.vector3fs {
             if v.name == name {
@@ -567,7 +567,7 @@ impl ParamSet {
         }
         values
     }
-    pub fn find_normal3f(&self, name: String) -> Vec<Normal3f> {
+    pub fn find_normal3f(&self, name: &str) -> Vec<Normal3f> {
         let mut values: Vec<Normal3f> = Vec::new();
         for v in &self.normals {
             if v.name == name {
@@ -580,7 +580,7 @@ impl ParamSet {
         }
         values
     }
-    pub fn find_spectrum(&self, name: String) -> Vec<Spectrum> {
+    pub fn find_spectrum(&self, name: &str) -> Vec<Spectrum> {
         let mut values: Vec<Spectrum> = Vec::new();
         for v in &self.spectra {
             if v.name == name {
@@ -619,14 +619,14 @@ impl TextureParams {
     }
     pub fn get_spectrum_texture(
         &mut self,
-        n: String,
+        n: &str,
         def: Spectrum,
     ) -> Arc<Texture<Spectrum> + Send + Sync> {
-        let mut name: String = self.geom_params.find_texture(n.clone());
-        if name == String::new() {
-            name = self.material_params.find_texture(n.clone());
+        let mut name: String = self.geom_params.find_texture(n);
+        if name == "" {
+            name = self.material_params.find_texture(n);
         }
-        if name != String::new() {
+        if name != "" {
             match self.spectrum_textures.get(name.as_str()) {
                 Some(spectrum_texture) => {
                     return spectrum_texture.clone();
@@ -645,11 +645,11 @@ impl TextureParams {
     }
     pub fn get_spectrum_texture_or_null(
         &mut self,
-        n: String,
+        n: &str,
     ) -> Option<Arc<Texture<Spectrum> + Send + Sync>> {
-        let mut name: String = self.geom_params.find_texture(n.clone());
+        let mut name: String = self.geom_params.find_texture(n);
         if name == String::new() {
-            name = self.material_params.find_texture(n.clone());
+            name = self.material_params.find_texture(n);
         }
         if name != String::new() {
             match self.spectrum_textures.get(name.as_str()) {
@@ -663,9 +663,9 @@ impl TextureParams {
                 }
             }
         }
-        let mut val: Vec<Spectrum> = self.material_params.find_spectrum(n.clone());
+        let mut val: Vec<Spectrum> = self.material_params.find_spectrum(n);
         if val.len() == 0_usize {
-            val = self.geom_params.find_spectrum(n.clone());
+            val = self.geom_params.find_spectrum(n);
         }
         if val.len() == 0_usize {
             None
@@ -673,27 +673,23 @@ impl TextureParams {
             Some(Arc::new(ConstantTexture { value: val[0] }))
         }
     }
-    pub fn get_float_texture(
-        &mut self,
-        n: String,
-        def: Float,
-    ) -> Arc<Texture<Float> + Send + Sync> {
-        let tex_option = self.get_float_texture_or_null(n.clone());
+    pub fn get_float_texture(&mut self, n: &str, def: Float) -> Arc<Texture<Float> + Send + Sync> {
+        let tex_option = self.get_float_texture_or_null(n);
         if let Some(tex) = tex_option {
             tex
         } else {
-            let mut val: Float = self.material_params.find_one_float(n.clone(), def);
-            val = self.geom_params.find_one_float(n.clone(), val);
+            let mut val: Float = self.material_params.find_one_float(n, def);
+            val = self.geom_params.find_one_float(n, val);
             Arc::new(ConstantTexture { value: val })
         }
     }
     pub fn get_float_texture_or_null(
         &mut self,
-        n: String,
+        n: &str,
     ) -> Option<Arc<Texture<Float> + Send + Sync>> {
-        let mut name: String = self.geom_params.find_texture(n.clone());
+        let mut name: String = self.geom_params.find_texture(n);
         if name == String::new() {
-            let s: Vec<Float> = self.geom_params.find_float(n.clone());
+            let s: Vec<Float> = self.geom_params.find_float(n);
             if s.len() > 1 {
                 println!(
                     "Ignoring excess values provided with parameter \"{}\"",
@@ -702,7 +698,7 @@ impl TextureParams {
             } else if s.len() != 0 {
                 return Some(Arc::new(ConstantTexture { value: s[0] }));
             }
-            name = self.material_params.find_texture(n.clone());
+            name = self.material_params.find_texture(n);
         }
         if name != String::new() {
             match self.float_textures.get(name.as_str()) {
@@ -718,9 +714,9 @@ impl TextureParams {
                 }
             }
         }
-        let mut val: Vec<Float> = self.material_params.find_float(n.clone());
+        let mut val: Vec<Float> = self.material_params.find_float(n);
         if val.len() == 0_usize {
-            val = self.geom_params.find_float(n.clone());
+            val = self.geom_params.find_float(n);
         }
         if val.len() == 0_usize {
             None
@@ -728,46 +724,34 @@ impl TextureParams {
             Some(Arc::new(ConstantTexture { value: val[0] }))
         }
     }
-    pub fn find_float(&mut self, name: String, d: Float) -> Float {
-        self.geom_params.find_one_float(
-            name.clone(),
-            self.material_params.find_one_float(name.clone(), d),
-        )
+    pub fn find_float(&mut self, name: &str, d: Float) -> Float {
+        self.geom_params
+            .find_one_float(name, self.material_params.find_one_float(name, d))
     }
-    pub fn find_string(&mut self, name: String, d: String) -> String {
-        self.geom_params.find_one_string(
-            name.clone(),
-            self.material_params.find_one_string(name.clone(), d),
-        )
+    pub fn find_string(&mut self, name: &str, d: String) -> String {
+        self.geom_params
+            .find_one_string(name, self.material_params.find_one_string(name, d))
     }
-    pub fn find_filename(&mut self, name: String, d: String) -> String {
-        self.geom_params.find_one_filename(
-            name.clone(),
-            self.material_params.find_one_filename(name.clone(), d),
-        )
+    pub fn find_filename(&mut self, name: &str, d: String) -> String {
+        self.geom_params
+            .find_one_filename(name, self.material_params.find_one_filename(name, d))
     }
-    pub fn find_int(&mut self, name: String, d: i32) -> i32 {
-        self.geom_params.find_one_int(
-            name.clone(),
-            self.material_params.find_one_int(name.clone(), d),
-        )
+    pub fn find_int(&mut self, name: &str, d: i32) -> i32 {
+        self.geom_params
+            .find_one_int(name, self.material_params.find_one_int(name, d))
     }
-    pub fn find_bool(&mut self, name: String, d: bool) -> bool {
-        self.geom_params.find_one_bool(
-            name.clone(),
-            self.material_params.find_one_bool(name.clone(), d),
-        )
+    pub fn find_bool(&mut self, name: &str, d: bool) -> bool {
+        self.geom_params
+            .find_one_bool(name, self.material_params.find_one_bool(name, d))
     }
-    pub fn find_vector3f(&mut self, name: String, d: Vector3f) -> Vector3f {
-        self.geom_params.find_one_vector3f(
-            name.clone(),
-            self.material_params.find_one_vector3f(name.clone(), d),
-        )
+    pub fn find_vector3f(&mut self, name: &str, d: Vector3f) -> Vector3f {
+        self.geom_params
+            .find_one_vector3f(name, self.material_params.find_one_vector3f(name, d))
     }
 }
 
 /// Replaces a macro on the C++ side.
-pub fn lookup_one<T>(vec: &Vec<ParamSetItem<T>>, name: String, d: T) -> T
+pub fn lookup_one<T>(vec: &Vec<ParamSetItem<T>>, name: &str, d: T) -> T
 where
     T: Clone,
 {

--- a/src/filters/boxfilter.rs
+++ b/src/filters/boxfilter.rs
@@ -17,8 +17,8 @@ pub struct BoxFilter {
 
 impl BoxFilter {
     pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
-        let xw: Float = ps.find_one_float(String::from("xwidth"), 0.5);
-        let yw: Float = ps.find_one_float(String::from("ywidth"), 0.5);
+        let xw: Float = ps.find_one_float("xwidth", 0.5);
+        let yw: Float = ps.find_one_float("ywidth", 0.5);
         let box_filter: Arc<Filter + Sync + Send> = Arc::new(BoxFilter {
             radius: Vector2f { x: xw, y: yw },
             inv_radius: Vector2f {

--- a/src/filters/gaussian.rs
+++ b/src/filters/gaussian.rs
@@ -20,9 +20,9 @@ pub struct GaussianFilter {
 
 impl GaussianFilter {
     pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
-        let xw: Float = ps.find_one_float(String::from("xwidth"), 2.0);
-        let yw: Float = ps.find_one_float(String::from("ywidth"), 2.0);
-        let alpha: Float = ps.find_one_float(String::from("alpha"), 2.0);
+        let xw: Float = ps.find_one_float("xwidth", 2.0);
+        let yw: Float = ps.find_one_float("ywidth", 2.0);
+        let alpha: Float = ps.find_one_float("alpha", 2.0);
         // see gaussian.h (GaussianFilter constructor)
         let exp_x: Float = (-alpha * xw * xw).exp();
         let exp_y: Float = (-alpha * yw * yw).exp();

--- a/src/filters/mitchell.rs
+++ b/src/filters/mitchell.rs
@@ -45,10 +45,10 @@ impl MitchellNetravali {
     }
 
     pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
-        let xw = ps.find_one_float(String::from("xwidth"), 2.0);
-        let yw = ps.find_one_float(String::from("ywidth"), 2.0);
-        let b = ps.find_one_float(String::from("B"), 1.0 / 3.0);
-        let c = ps.find_one_float(String::from("C"), 1.0 / 3.0);
+        let xw = ps.find_one_float("xwidth", 2.0);
+        let yw = ps.find_one_float("ywidth", 2.0);
+        let b = ps.find_one_float("B", 1.0 / 3.0);
+        let c = ps.find_one_float("C", 1.0 / 3.0);
 
         Arc::new(Self::new(xw, yw, b, c))
     }

--- a/src/filters/triangle.rs
+++ b/src/filters/triangle.rs
@@ -17,8 +17,8 @@ pub struct TriangleFilter {
 
 impl TriangleFilter {
     pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
-        let xw: Float = ps.find_one_float(String::from("xwidth"), 2.0);
-        let yw: Float = ps.find_one_float(String::from("ywidth"), 2.0);
+        let xw: Float = ps.find_one_float("xwidth", 2.0);
+        let yw: Float = ps.find_one_float("ywidth", 2.0);
         let triangle_filter: Arc<Filter + Sync + Send> = Arc::new(TriangleFilter {
             radius: Vector2f { x: xw, y: yw },
             inv_radius: Vector2f {

--- a/src/materials/fourier.rs
+++ b/src/materials/fourier.rs
@@ -31,8 +31,8 @@ impl FourierMaterial {
         bsdf_state: &mut BsdfState,
     ) -> Arc<Material + Send + Sync> {
         let bump_map: Option<Arc<Texture<Float> + Send + Sync>> =
-            mp.get_float_texture_or_null(String::from("bumpmap"));
-        let bsdffile: String = mp.find_filename(String::from("bsdffile"), String::new());
+            mp.get_float_texture_or_null("bumpmap");
+        let bsdffile: String = mp.find_filename("bsdffile", String::new());
         if let Some(bsdf_table) = bsdf_state.loaded_bsdfs.get(&bsdffile.clone()) {
             // use the BSDF table found
             Arc::new(FourierMaterial::new(bsdf_table.clone(), bump_map))

--- a/src/materials/matte.rs
+++ b/src/materials/matte.rs
@@ -31,14 +31,14 @@ impl MatteMaterial {
     }
     pub fn create(mp: &mut TextureParams) -> Arc<Material + Send + Sync> {
         let kd: Arc<Texture<Spectrum> + Sync + Send> =
-            mp.get_spectrum_texture(String::from("Kd"), Spectrum::new(0.5));
-        let sigma: Arc<Texture<Float> + Sync + Send> =
-            mp.get_float_texture(String::from("sigma"), 0.0);
+            mp.get_spectrum_texture("Kd", Spectrum::new(0.5));
+        let sigma: Arc<Texture<Float> + Sync + Send> = mp.get_float_texture("sigma", 0.0);
         Arc::new(MatteMaterial { kd, sigma })
     }
     pub fn bsdf(&self, si: &SurfaceInteraction) -> Bsdf {
         let mut bxdfs: Vec<Arc<Bxdf + Send + Sync>> = Vec::new();
-        let r: Spectrum = self.kd
+        let r: Spectrum = self
+            .kd
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
         let sig: Float = clamp_t(

--- a/src/materials/metal.rs
+++ b/src/materials/metal.rs
@@ -115,20 +115,18 @@ impl MetalMaterial {
     pub fn create(mp: &mut TextureParams) -> Arc<Material + Send + Sync> {
         let copper_n: Spectrum =
             Spectrum::from_sampled(&COPPER_WAVELENGTHS, &COPPER_N, COPPER_SAMPLES as i32);
-        let eta: Arc<Texture<Spectrum> + Send + Sync> =
-            mp.get_spectrum_texture(String::from("eta"), copper_n);
+        let eta: Arc<Texture<Spectrum> + Send + Sync> = mp.get_spectrum_texture("eta", copper_n);
         let copper_k: Spectrum =
             Spectrum::from_sampled(&COPPER_WAVELENGTHS, &COPPER_K, COPPER_SAMPLES as i32);
-        let k: Arc<Texture<Spectrum> + Send + Sync> =
-            mp.get_spectrum_texture(String::from("k"), copper_k);
+        let k: Arc<Texture<Spectrum> + Send + Sync> = mp.get_spectrum_texture("k", copper_k);
         let roughness: Arc<Texture<Float> + Send + Sync> =
-            mp.get_float_texture(String::from("roughness"), 0.01 as Float);
+            mp.get_float_texture("roughness", 0.01 as Float);
         let u_roughness: Option<Arc<Texture<Float> + Send + Sync>> =
-            mp.get_float_texture_or_null(String::from("uroughness"));
+            mp.get_float_texture_or_null("uroughness");
         let v_roughness: Option<Arc<Texture<Float> + Send + Sync>> =
-            mp.get_float_texture_or_null(String::from("vroughness"));
+            mp.get_float_texture_or_null("vroughness");
         // TODO: std::shared_ptr<Texture<Float>> bumpMap = mp.GetFloatTextureOrNull("bumpmap");
-        let remap_roughness: bool = mp.find_bool(String::from("remaproughness"), true);
+        let remap_roughness: bool = mp.find_bool("remaproughness", true);
         Arc::new(MetalMaterial::new(
             eta,
             k,

--- a/src/materials/substrate.rs
+++ b/src/materials/substrate.rs
@@ -40,14 +40,12 @@ impl SubstrateMaterial {
     }
     pub fn create(mp: &mut TextureParams) -> Arc<Material + Send + Sync> {
         let kd: Arc<Texture<Spectrum> + Sync + Send> =
-            mp.get_spectrum_texture(String::from("Kd"), Spectrum::new(0.5));
+            mp.get_spectrum_texture("Kd", Spectrum::new(0.5));
         let ks: Arc<Texture<Spectrum> + Sync + Send> =
-            mp.get_spectrum_texture(String::from("Ks"), Spectrum::new(0.5));
-        let uroughness: Arc<Texture<Float> + Sync + Send> =
-            mp.get_float_texture(String::from("uroughness"), 0.1);
-        let vroughness: Arc<Texture<Float> + Sync + Send> =
-            mp.get_float_texture(String::from("vroughness"), 0.1);
-        let remap_roughness: bool = mp.find_bool(String::from("remaproughness"), true);
+            mp.get_spectrum_texture("Ks", Spectrum::new(0.5));
+        let uroughness: Arc<Texture<Float> + Sync + Send> = mp.get_float_texture("uroughness", 0.1);
+        let vroughness: Arc<Texture<Float> + Sync + Send> = mp.get_float_texture("vroughness", 0.1);
+        let remap_roughness: bool = mp.find_bool("remaproughness", true);
         Arc::new(SubstrateMaterial::new(
             kd,
             ks,
@@ -58,10 +56,12 @@ impl SubstrateMaterial {
     }
     pub fn bsdf(&self, si: &SurfaceInteraction) -> Bsdf {
         let mut bxdfs: Vec<Arc<Bxdf + Send + Sync>> = Vec::new();
-        let d: Spectrum = self.kd
+        let d: Spectrum = self
+            .kd
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
-        let s: Spectrum = self.ks
+        let s: Spectrum = self
+            .ks
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
         let mut roughu: Float = self.nu.evaluate(si);

--- a/src/materials/uber.rs
+++ b/src/materials/uber.rs
@@ -59,26 +59,26 @@ impl UberMaterial {
     }
     pub fn create(mp: &mut TextureParams) -> Arc<Material + Send + Sync> {
         let kd: Arc<Texture<Spectrum> + Sync + Send> =
-            mp.get_spectrum_texture(String::from("Kd"), Spectrum::new(0.25));
+            mp.get_spectrum_texture("Kd", Spectrum::new(0.25));
         let ks: Arc<Texture<Spectrum> + Sync + Send> =
-            mp.get_spectrum_texture(String::from("Ks"), Spectrum::new(0.25));
+            mp.get_spectrum_texture("Ks", Spectrum::new(0.25));
         let kr: Arc<Texture<Spectrum> + Sync + Send> =
-            mp.get_spectrum_texture(String::from("Kr"), Spectrum::new(0.0));
+            mp.get_spectrum_texture("Kr", Spectrum::new(0.0));
         let kt: Arc<Texture<Spectrum> + Sync + Send> =
-            mp.get_spectrum_texture(String::from("Kt"), Spectrum::new(0.0));
+            mp.get_spectrum_texture("Kt", Spectrum::new(0.0));
         let roughness: Arc<Texture<Float> + Send + Sync> =
-            mp.get_float_texture(String::from("roughness"), 0.1 as Float);
+            mp.get_float_texture("roughness", 0.1 as Float);
         let u_roughness: Option<Arc<Texture<Float> + Send + Sync>> =
-            mp.get_float_texture_or_null(String::from("uroughness"));
+            mp.get_float_texture_or_null("uroughness");
         let v_roughness: Option<Arc<Texture<Float> + Send + Sync>> =
-            mp.get_float_texture_or_null(String::from("vroughness"));
+            mp.get_float_texture_or_null("vroughness");
         let opacity: Arc<Texture<Spectrum> + Send + Sync> =
-            mp.get_spectrum_texture(String::from("opacity"), Spectrum::new(1.0));
+            mp.get_spectrum_texture("opacity", Spectrum::new(1.0));
         let bump_map: Option<Arc<Texture<Float> + Send + Sync>> =
-            mp.get_float_texture_or_null(String::from("bumpmap"));
-        let remap_roughness: bool = mp.find_bool(String::from("remaproughness"), true);
+            mp.get_float_texture_or_null("bumpmap");
+        let remap_roughness: bool = mp.find_bool("remaproughness", true);
         let eta_option: Option<Arc<Texture<Float> + Send + Sync>> =
-            mp.get_float_texture_or_null(String::from("eta"));
+            mp.get_float_texture_or_null("eta");
         if let Some(ref eta) = eta_option {
             Arc::new(UberMaterial::new(
                 kd,
@@ -94,8 +94,7 @@ impl UberMaterial {
                 remap_roughness,
             ))
         } else {
-            let eta: Arc<Texture<Float> + Send + Sync> =
-                mp.get_float_texture(String::from("eta"), 1.5 as Float);
+            let eta: Arc<Texture<Float> + Send + Sync> = mp.get_float_texture("eta", 1.5 as Float);
             Arc::new(UberMaterial::new(
                 kd,
                 ks,
@@ -117,7 +116,8 @@ impl UberMaterial {
             UberMaterial::bump(bump_map, si);
         }
         let e: Float = self.eta.evaluate(si);
-        let op: Spectrum = self.opacity
+        let op: Spectrum = self
+            .opacity
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
         let t: Spectrum =
@@ -130,13 +130,15 @@ impl UberMaterial {
                 mode.clone(),
             )));
         }
-        let kd: Spectrum = op * self.kd
+        let kd: Spectrum = op * self
+            .kd
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
         if !kd.is_black() {
             bxdfs.push(Arc::new(LambertianReflection::new(kd)));
         }
-        let ks: Spectrum = op * self.ks
+        let ks: Spectrum = op * self
+            .ks
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
         if !ks.is_black() {
@@ -164,7 +166,8 @@ impl UberMaterial {
                 Some(TrowbridgeReitzDistribution::new(u_rough, v_rough, true));
             bxdfs.push(Arc::new(MicrofacetReflection::new(ks, distrib, fresnel)));
         }
-        let kr: Spectrum = op * self.kr
+        let kr: Spectrum = op * self
+            .kr
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
         if !kr.is_black() {
@@ -174,7 +177,8 @@ impl UberMaterial {
             });
             bxdfs.push(Arc::new(SpecularReflection::new(kr, fresnel)));
         }
-        let kt: Spectrum = op * self.kt
+        let kt: Spectrum = op * self
+            .kt
             .evaluate(si)
             .clamp(0.0 as Float, std::f32::INFINITY as Float);
         if !kt.is_black() {

--- a/src/shapes/curve.rs
+++ b/src/shapes/curve.rs
@@ -1,10 +1,12 @@
 // std
 use std::sync::Arc;
 // pbrt
+use core::geometry::{
+    bnd3_expand, bnd3_union_bnd3, nrm_abs_dot_vec3, nrm_cross_vec3, nrm_dot_nrm, nrm_normalize,
+    pnt3_distance, pnt3_distance_squared, pnt3_lerp, vec2_dot, vec3_coordinate_system,
+    vec3_cross_vec3, vec3_normalize,
+};
 use core::geometry::{Bounds3f, Normal3f, Point2f, Point3f, Ray, Vector2f, Vector3f};
-use core::geometry::{nrm_dot_nrm, nrm_normalize, bnd3_expand, bnd3_union_bnd3, nrm_abs_dot_vec3,
-                     nrm_cross_vec3, pnt3_distance, pnt3_distance_squared, pnt3_lerp, vec2_dot,
-                     vec3_coordinate_system, vec3_cross_vec3, vec3_normalize};
 use core::interaction::{Interaction, InteractionCommon, SurfaceInteraction};
 use core::material::Material;
 use core::paramset::ParamSet;
@@ -371,7 +373,8 @@ impl Shape for Curve {
         // transform _Ray_ to object space
         let mut o_err: Vector3f = Vector3f::default();
         let mut d_err: Vector3f = Vector3f::default();
-        let ray: Ray = self.world_to_object
+        let ray: Ray = self
+            .world_to_object
             .transform_ray_with_error(r, &mut o_err, &mut d_err);
 
         // compute object-space control points for curve segment, _cp_obj_
@@ -553,18 +556,17 @@ pub fn create_curve_shape(
     reverse_orientation: bool,
     params: &ParamSet,
 ) -> Vec<Arc<Shape + Send + Sync>> {
-    let width: Float = params.find_one_float(String::from("width"), 1.0 as Float);
-    let width0: Float = params.find_one_float(String::from("width0"), width);
-    let width1: Float = params.find_one_float(String::from("width1"), width);
-    let cp = params.find_point3f(String::from("P"));
+    let width: Float = params.find_one_float("width", 1.0 as Float);
+    let width0: Float = params.find_one_float("width0", width);
+    let width1: Float = params.find_one_float("width1", width);
+    let cp = params.find_point3f("P");
     if cp.len() != 4_usize {
         panic!(
             "Must provide 4 control points for \"curve\" primitive. ((Provided {:?}).",
             cp.len()
         );
     }
-    let curve_type_string: String =
-        params.find_one_string(String::from("type"), String::from("flat"));
+    let curve_type_string: String = params.find_one_string("type", String::from("flat"));
     let mut curve_type: CurveType = CurveType::Flat;
     if curve_type_string == String::from("flat") {
         curve_type = CurveType::Flat;
@@ -578,7 +580,7 @@ pub fn create_curve_shape(
             curve_type_string
         );
     }
-    let mut n: Vec<Normal3f> = params.find_normal3f(String::from("N"));
+    let mut n: Vec<Normal3f> = params.find_normal3f("N");
     if !n.is_empty() {
         if curve_type_string != String::from("ribbon") {
             println!("WARNING: Curve normals are only used with \"ribbon\" type curves.");
@@ -590,7 +592,7 @@ pub fn create_curve_shape(
             );
         }
     }
-    let sd: i32 = params.find_one_int(String::from("splitdepth"), 3_i32);
+    let sd: i32 = params.find_one_int("splitdepth", 3_i32);
     if curve_type == CurveType::Ribbon && n.is_empty() {
         panic!("Must provide normals \"N\" at curve endpoints with ribbon curves.");
     }

--- a/src/shapes/plymesh.rs
+++ b/src/shapes/plymesh.rs
@@ -28,7 +28,7 @@ pub fn create_ply_mesh(
     _float_textures: HashMap<String, Arc<Texture<Float> + Send + Sync>>,
     search_directory: Option<&Box<PathBuf>>,
 ) -> Vec<Arc<Shape + Send + Sync>> {
-    let mut filename: String = params.find_one_string(String::from("filename"), String::new());
+    let mut filename: String = params.find_one_string("filename", String::new());
     if let Some(ref search_directory) = search_directory {
         let mut path_buf: PathBuf = PathBuf::from("/");
         path_buf.push(search_directory.as_ref());


### PR DESCRIPTION
Change the `name` argument of the `ParamSet::find_xxx()` methods to take
an `&str` instead a `String`. This removes a lot of allocations and
clones, and makes the api more ergonomic.

Closes #74 