### PR TITLE
De-Arc-ify filter

### DIFF
--- a/examples/cameras_perspective_generate_ray_differential.rs
+++ b/examples/cameras_perspective_generate_ray_differential.rs
@@ -28,7 +28,7 @@ fn main() {
     // PerspectiveCamera
     let xw: Float = 0.5;
     let yw: Float = 0.5;
-    let filter: Arc<Filter + Sync + Send> = Arc::new(BoxFilter {
+    let filter: Box<Filter + Sync + Send> = Box::new(BoxFilter {
         radius: Vector2f { x: xw, y: yw },
         inv_radius: Vector2f {
             x: 1.0 / xw,

--- a/examples/parse_ass_file.rs
+++ b/examples/parse_ass_file.rs
@@ -1242,7 +1242,7 @@ fn main() {
         println!("number of lights = {:?}", lights.len());
         println!("number of primitives = {:?}", primitives.len());
         // MakeFilter
-        let mut some_filter: Option<Arc<Filter + Sync + Send>> = None;
+        let mut some_filter: Option<Box<Filter + Sync + Send>> = None;
         if filter_name == "box" {
             println!("TODO: CreateBoxFilter");
         } else if filter_name == "gaussian" {

--- a/examples/parse_blend_file.rs
+++ b/examples/parse_blend_file.rs
@@ -2513,7 +2513,7 @@ fn main() -> std::io::Result<()> {
     };
     let xw: Float = 0.5;
     let yw: Float = 0.5;
-    let filter: Arc<Filter + Sync + Send> = Arc::new(BoxFilter {
+    let filter: Box<Filter + Sync + Send> = Box::new(BoxFilter {
         radius: Vector2f { x: xw, y: yw },
         inv_radius: Vector2f {
             x: 1.0 / xw,

--- a/examples/pbrt_spheres_differentials_texfilt.rs
+++ b/examples/pbrt_spheres_differentials_texfilt.rs
@@ -591,7 +591,7 @@ fn main() {
     };
     let xw: Float = 0.5;
     let yw: Float = 0.5;
-    let filter: Arc<Filter + Sync + Send> = Arc::new(BoxFilter {
+    let filter: Box<Filter + Sync + Send> = Box::new(BoxFilter {
         radius: Vector2f { x: xw, y: yw },
         inv_radius: Vector2f {
             x: 1.0 / xw,

--- a/examples/pbrt_teapot_area_light.rs
+++ b/examples/pbrt_teapot_area_light.rs
@@ -2014,7 +2014,7 @@ fn main() {
     };
     let xw: Float = 0.5;
     let yw: Float = 0.5;
-    let filter: Arc<Filter + Sync + Send> = Arc::new(BoxFilter {
+    let filter: Box<Filter + Sync + Send> = Box::new(BoxFilter {
         radius: Vector2f { x: xw, y: yw },
         inv_radius: Vector2f {
             x: 1.0 / xw,

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -1575,7 +1575,7 @@ pub fn pbrt_cleanup(api_state: &ApiState) {
         "Missing end to pbrtTransformBegin()"
     );
     // MakeFilter
-    let mut some_filter: Option<Arc<Filter + Sync + Send>> = None;
+    let mut some_filter: Option<Box<Filter + Sync + Send>> = None;
     if api_state.render_options.filter_name == "box" {
         some_filter = Some(BoxFilter::create(&api_state.render_options.filter_params));
     } else if api_state.render_options.filter_name == "gaussian" {

--- a/src/core/film.rs
+++ b/src/core/film.rs
@@ -14,7 +14,8 @@
 use std;
 use std::ops::{DerefMut, Index};
 use std::path::Path;
-use std::sync::{Arc, RwLock, RwLockWriteGuard};
+use std::sync::{RwLock, RwLockWriteGuard};
+
 // others
 use image;
 #[cfg(feature = "openexr")]
@@ -163,7 +164,7 @@ pub struct Film {
     /// The length of the diagonal of the film's physical area (specified in mm, stored in meters)
     pub diagonal: Float,
     /// A filter function
-    pub filter: Arc<Filter + Sync + Send>,
+    pub filter: Box<Filter + Sync + Send>,
     /// The filename of the output image
     pub filename: String,
     /// A crop window that may specify a subset of the image to render
@@ -180,7 +181,7 @@ impl Film {
     pub fn new(
         resolution: Point2i,
         crop_window: Bounds2f,
-        filter: Arc<Filter + Sync + Send>,
+        filter: Box<Filter + Sync + Send>,
         diagonal: Float,
         filename: String,
         scale: Float,

--- a/src/filters/boxfilter.rs
+++ b/src/filters/boxfilter.rs
@@ -1,5 +1,3 @@
-//std
-use std::sync::Arc;
 // pbrt
 use crate::core::filter::Filter;
 use crate::core::geometry::{Point2f, Vector2f};
@@ -16,10 +14,10 @@ pub struct BoxFilter {
 }
 
 impl BoxFilter {
-    pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
+    pub fn create(ps: &ParamSet) -> Box<Filter + Sync + Send> {
         let xw: Float = ps.find_one_float("xwidth", 0.5);
         let yw: Float = ps.find_one_float("ywidth", 0.5);
-        let box_filter: Arc<Filter + Sync + Send> = Arc::new(BoxFilter {
+        let box_filter: Box<Filter + Sync + Send> = Box::new(BoxFilter {
             radius: Vector2f { x: xw, y: yw },
             inv_radius: Vector2f {
                 x: 1.0 / xw,

--- a/src/filters/gaussian.rs
+++ b/src/filters/gaussian.rs
@@ -1,5 +1,3 @@
-//std
-use std::sync::Arc;
 // pbrt
 use crate::core::filter::Filter;
 use crate::core::geometry::{Point2f, Vector2f};
@@ -19,14 +17,14 @@ pub struct GaussianFilter {
 }
 
 impl GaussianFilter {
-    pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
+    pub fn create(ps: &ParamSet) -> Box<Filter + Sync + Send> {
         let xw: Float = ps.find_one_float("xwidth", 2.0);
         let yw: Float = ps.find_one_float("ywidth", 2.0);
         let alpha: Float = ps.find_one_float("alpha", 2.0);
         // see gaussian.h (GaussianFilter constructor)
         let exp_x: Float = (-alpha * xw * xw).exp();
         let exp_y: Float = (-alpha * yw * yw).exp();
-        let gaussian_filter: Arc<Filter + Sync + Send> = Arc::new(GaussianFilter {
+        let gaussian_filter: Box<Filter + Sync + Send> = Box::new(GaussianFilter {
             alpha: alpha,
             exp_x: exp_x,
             exp_y: exp_y,

--- a/src/filters/mitchell.rs
+++ b/src/filters/mitchell.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::core::filter::Filter;
 use crate::core::geometry::{Point2f, Vector2f};
 use crate::core::paramset::ParamSet;
@@ -44,13 +42,13 @@ impl MitchellNetravali {
         }
     }
 
-    pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
+    pub fn create(ps: &ParamSet) -> Box<Filter + Sync + Send> {
         let xw = ps.find_one_float("xwidth", 2.0);
         let yw = ps.find_one_float("ywidth", 2.0);
         let b = ps.find_one_float("B", 1.0 / 3.0);
         let c = ps.find_one_float("C", 1.0 / 3.0);
 
-        Arc::new(Self::new(xw, yw, b, c))
+        Box::new(Self::new(xw, yw, b, c))
     }
 }
 

--- a/src/filters/triangle.rs
+++ b/src/filters/triangle.rs
@@ -1,5 +1,3 @@
-//std
-use std::sync::Arc;
 // pbrt
 use crate::core::filter::Filter;
 use crate::core::geometry::{Point2f, Vector2f};
@@ -16,10 +14,10 @@ pub struct TriangleFilter {
 }
 
 impl TriangleFilter {
-    pub fn create(ps: &ParamSet) -> Arc<Filter + Sync + Send> {
+    pub fn create(ps: &ParamSet) -> Box<Filter + Sync + Send> {
         let xw: Float = ps.find_one_float("xwidth", 2.0);
         let yw: Float = ps.find_one_float("ywidth", 2.0);
-        let triangle_filter: Arc<Filter + Sync + Send> = Arc::new(TriangleFilter {
+        let triangle_filter: Box<Filter + Sync + Send> = Box::new(TriangleFilter {
             radius: Vector2f { x: xw, y: yw },
             inv_radius: Vector2f {
                 x: 1.0 / xw,


### PR DESCRIPTION
There's no reason to use a costly Arc for a function-only trait

Signed-off-by: Daniel Egger <daniel@eggers-club.de>