### PR TITLE
Pick up some cheap gains by using the crossbeam_channel crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "atomic 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hexf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,33 @@
 [package]
-name = "pbrt"
-version = "0.6.2"
 authors = ["Jan Walter <jan@janwalter.com>"]
 edition = "2018"
-
-[features]
-default = ["openexr"]
-
+name = "pbrt"
+version = "0.6.2"
 [dependencies]
-
 atom = "0.3.5"
 atomic = "0.4"
 byteorder = "1"
 crossbeam = "0.7"
-getopts="0.2.15"
-half="1"
+crossbeam-channel = "0.3"
+getopts = "0.2.15"
+half = "1"
 hexf = "0.1.0"
-image="*"
+image = "*"
 lazy_static = "1.2.0"
-num="*"
+num = "*"
 num_cpus = "1.2"
-openexr = { version = "0.6", optional = true }
 pbr = "1.0"
 pest = "2.0"
 pest_derive = "2.0"
 ply-rs = "0.1.2"
 rayon = "1.0"
+structopt = "0.2"
 time = "0.1"
 typed-arena = "1.3.0"
-structopt = "0.2"
+
+[dependencies.openexr]
+optional = true
+version = "0.6"
+
+[features]
+default = ["openexr"]

--- a/src/cameras/realistic.rs
+++ b/src/cameras/realistic.rs
@@ -1,7 +1,6 @@
 // std
 use std;
 use std::path::PathBuf;
-use std::sync::mpsc;
 use std::sync::Arc;
 // pbrt
 use crate::core::camera::{Camera, CameraSample};
@@ -105,7 +104,7 @@ impl RealisticCamera {
             let camera = &camera;
             let film = &film;
             crossbeam::scope(|scope| {
-                let (band_tx, band_rx) = mpsc::channel();
+                let (band_tx, band_rx) = crossbeam_channel::bounded(num_cores);
                 // spawn worker threads
                 for (b, band) in bands.into_iter().enumerate() {
                     let band_tx = band_tx.clone();

--- a/src/integrators/bdpt.rs
+++ b/src/integrators/bdpt.rs
@@ -1,6 +1,5 @@
 // std
 use std::f32::consts::PI;
-use std::sync::mpsc;
 use std::sync::Arc;
 // pbrt
 use crate::blockqueue::BlockQueue;
@@ -2239,7 +2238,7 @@ pub fn render_bdpt(
             let film = &film;
             // let pixel_bounds = integrator.get_pixel_bounds().clone();
             crossbeam::scope(|scope| {
-                let (pixel_tx, pixel_rx) = mpsc::channel();
+                let (pixel_tx, pixel_rx) = crossbeam_channel::bounded(num_cores);
                 // spawn worker threads
                 for _ in 0..num_cores {
                     let pixel_tx = pixel_tx.clone();

--- a/src/integrators/mlt.rs
+++ b/src/integrators/mlt.rs
@@ -1,5 +1,4 @@
 // std
-use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
 // pbrt
@@ -412,7 +411,7 @@ pub fn render_mlt(
                 let integrator = &integrator;
                 let light_distr = &light_distr;
                 crossbeam::scope(|scope| {
-                    let (band_tx, band_rx) = mpsc::channel();
+                    let (band_tx, band_rx) = crossbeam_channel::bounded(num_cores);
                     // spawn worker threads
                     for (b, band) in bands.into_iter().enumerate() {
                         let band_tx = band_tx.clone();
@@ -459,7 +458,7 @@ pub fn render_mlt(
             // TODO: ProgressReporter progress(nTotalMutations / progressFrequency,
             //                           "Rendering");
             // use parallel iterator (par_iter_with) from rayon crate
-            let (sender, receiver) = mpsc::channel();
+            let (sender, receiver) = crossbeam_channel::bounded(num_cores);
             let n_chains = integrator.n_chains;
             // spawn thread to report progress
             let finish = thread::spawn(move || {

--- a/src/integrators/mod.rs
+++ b/src/integrators/mod.rs
@@ -59,7 +59,6 @@
 //! ![Stochastic Progressive Photon Mapping](/doc/img/caustic_glass_pbrt_rust_sppm.png)
 
 // std
-use std::sync::mpsc;
 use std::sync::Arc;
 // pbrt
 use crate::blockqueue::BlockQueue;
@@ -122,7 +121,7 @@ pub fn render(
         let film = &film;
         let pixel_bounds = integrator.get_pixel_bounds().clone();
         crossbeam::scope(|scope| {
-            let (pixel_tx, pixel_rx) = mpsc::channel();
+            let (pixel_tx, pixel_rx) = crossbeam_channel::bounded(num_cores);
             // spawn worker threads
             for _ in 0..num_cores {
                 let pixel_tx = pixel_tx.clone();

--- a/src/integrators/sppm.rs
+++ b/src/integrators/sppm.rs
@@ -1,6 +1,5 @@
 // std
 use std::f32::consts::PI;
-use std::sync::mpsc;
 use std::sync::Arc;
 // others
 use atom::*;
@@ -181,7 +180,7 @@ pub fn render_sppm(
                     let sampler = &sampler;
                     let pixels = &mut pixels;
                     crossbeam::scope(|scope| {
-                        let (pixel_tx, pixel_rx) = mpsc::channel();
+                        let (pixel_tx, pixel_rx) = crossbeam_channel::bounded(num_cores);
                         // spawn worker threads
                         for _ in 0..num_cores {
                             let pixel_tx = pixel_tx.clone();
@@ -416,7 +415,7 @@ pub fn render_sppm(
                     let bands: Vec<&mut [SPPMPixel]> = pixels.chunks_mut(chunk_size).collect();
                     let grid = &grid;
                     crossbeam::scope(|scope| {
-                        let (band_tx, band_rx) = mpsc::channel();
+                        let (band_tx, band_rx) = crossbeam_channel::bounded(num_cores);
                         // spawn worker threads
                         for (b, band) in bands.into_iter().enumerate() {
                             let band_tx = band_tx.clone();
@@ -508,7 +507,7 @@ pub fn render_sppm(
                     let integrator = &integrator;
                     let light_distr = &light_distr;
                     crossbeam::scope(|scope| {
-                        let (band_tx, band_rx) = mpsc::channel();
+                        let (band_tx, band_rx) = crossbeam_channel::bounded(num_cores);
                         // spawn worker threads
                         for (b, band) in bands.into_iter().enumerate() {
                             let band_tx = band_tx.clone();
@@ -764,7 +763,7 @@ pub fn render_sppm(
                 {
                     let bands: Vec<&mut [SPPMPixel]> = pixels.chunks_mut(chunk_size).collect();
                     crossbeam::scope(|scope| {
-                        let (band_tx, band_rx) = mpsc::channel();
+                        let (band_tx, band_rx) = crossbeam_channel::bounded(num_cores);
                         // spawn worker threads
                         for (b, band) in bands.into_iter().enumerate() {
                             let band_tx = band_tx.clone();


### PR DESCRIPTION
Swapping the unbounded mpsc::channel() against a bounded
crossbeam_channel::bounded () (bounded by the number of cores) improved
performance by up to 5% for me on the simple_room scene.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>